### PR TITLE
Fix bt state handling on ios

### DIFF
--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -32,7 +32,10 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     }
     
     func scan() {
-        if centralManager.isScanning == true { return }
+        if centralManager.isScanning == true { 
+            updateScanState()
+            return
+        }
         guard centralManager.state == .poweredOn else {
             updateScanState()
             return
@@ -65,7 +68,6 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     }
     
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        scanStateHandler.send(central.state.rawValue)
         updateScanState()
     }
     


### PR DESCRIPTION
Solves exception thrown when bt is turned on/off on phone and solves wrong bt state shown after app is restarted.