### PR TITLE
Feature: bt scan priority

### DIFF
--- a/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
+++ b/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
@@ -37,6 +37,16 @@ public class Pigeon {
     }
   }
 
+  public enum ScanPriority {
+    High(0),
+    Low(1);
+
+    private int index;
+    private ScanPriority(final int index) {
+      this.index = index;
+    }
+  }
+
   public enum MessageSource {
     BluetoothLegacy(0),
     BluetoothLongRange(1),
@@ -1577,7 +1587,7 @@ public class Pigeon {
     void startScanWifi(Result<Void> result);
     void stopScanBluetooth(Result<Void> result);
     void stopScanWifi(Result<Void> result);
-    void setAutorestartBluetooth(@NonNull Boolean enable, Result<Void> result);
+    void setBtScanPriority(@NonNull ScanPriority priority, Result<Void> result);
     void isScanningBluetooth(Result<Boolean> result);
     void isScanningWifi(Result<Boolean> result);
     void bluetoothState(Result<Long> result);
@@ -1711,15 +1721,15 @@ public class Pigeon {
       }
       {
         BasicMessageChannel<Object> channel =
-            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.Api.setAutorestartBluetooth", getCodec());
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.Api.setBtScanPriority", getCodec());
         if (api != null) {
           channel.setMessageHandler((message, reply) -> {
             Map<String, Object> wrapped = new HashMap<>();
             try {
               ArrayList<Object> args = (ArrayList<Object>)message;
-              Boolean enableArg = (Boolean)args.get(0);
-              if (enableArg == null) {
-                throw new NullPointerException("enableArg unexpectedly null.");
+              ScanPriority priorityArg = args.get(0) == null ? null : ScanPriority.values()[(int)args.get(0)];
+              if (priorityArg == null) {
+                throw new NullPointerException("priorityArg unexpectedly null.");
               }
               Result<Void> resultCallback = new Result<Void>() {
                 public void success(Void result) {
@@ -1732,7 +1742,7 @@ public class Pigeon {
                 }
               };
 
-              api.setAutorestartBluetooth(enableArg, resultCallback);
+              api.setBtScanPriority(priorityArg, resultCallback);
             }
             catch (Error | RuntimeException exception) {
               wrapped.put("error", wrapError(exception));

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
@@ -150,6 +150,11 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
         result.success(null)
     }
 
+    override fun setBtScanPriority(priority: Pigeon.ScanPriority, result: Pigeon.Result<Void>) {
+        scanner.setScanPriority(priority)
+        result.success(null)
+    }
+
     override fun isScanningBluetooth(result: Pigeon.Result<Boolean>){
       result.success(scanner.isScanning)
     }
@@ -178,10 +183,5 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
 
     override fun wifiNaNSupported(result: Pigeon.Result<Boolean>) {
         result.success(wifiNaNScanner.isWifiAwareSupported());
-    }
-
-    override fun setAutorestartBluetooth(enable: Boolean, result: Pigeon.Result<Void>) {
-        scanner.shouldAutoRestart = enable
-        result.success(null)
     }
 }

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -29,7 +29,7 @@ class BluetoothScanner(
             field = value
             bluetoothStateHandler.send(value)
         }
-    var shouldAutoRestart = false
+    var scanMode = ScanSettings.SCAN_MODE_LOW_LATENCY
     val bluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
     /* OpenDroneID Bluetooth beacons identify themselves by setting the GAP AD Type to
     * "Service Data - 16-bit UUID" and the value to 0xFFFA for ASTM International, ASTM Remote ID.
@@ -66,7 +66,7 @@ class BluetoothScanner(
                 bluetoothAdapter.isLeExtendedAdvertisingSupported
         ) {
             scanSettings = ScanSettings.Builder()
-                    .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+                    .setScanMode(scanMode)
                     .setLegacy(false)
                     .setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
                     .build()
@@ -75,6 +75,22 @@ class BluetoothScanner(
         bluetoothLeScanner.startScan(scanFilters, scanSettings, scanCallback)
         isScanning = true
         bluetoothStateHandler.send(true)
+    }
+
+    fun setScanPriority(priority: Pigeon.ScanPriority) {
+        if(priority == Pigeon.ScanPriority.High)
+        {
+            scanMode = ScanSettings.SCAN_MODE_LOW_LATENCY
+        }
+        else
+        {
+            scanMode =  ScanSettings.SCAN_MODE_LOW_POWER
+        }
+        if(isScanning){
+            bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
+            scan()
+        }
+
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
@@ -179,7 +195,7 @@ class BluetoothScanner(
                 if (bluetoothAdapter.isEnabled) bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
                 isScanning = false
             } else if ((rawState == BluetoothAdapter.STATE_ON)
-                    && !isScanning && shouldAutoRestart) {
+                    && !isScanning) {
                 cancel()
                 scan()
             }

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -86,6 +86,7 @@ class BluetoothScanner(
         {
             scanMode =  ScanSettings.SCAN_MODE_LOW_POWER
         }
+        // if scan is running, restart with updated scanMode
         if(isScanning){
             bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
             scan()

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -76,8 +76,8 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     func setScanPriority(priority: DTGScanPriority)
     {
         scanPriority = priority
-        // if scanning, restart and set timer if high
-        // otherwise cancel timer
+        // if scan is running when settting high prio, call scan to restart and set timer
+        // if scan is running when setting low prio, just cancel restart timer
         if centralManager.isScanning {
             if scanPriority == .low {
                 restartTimer?.invalidate()
@@ -88,6 +88,7 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
             }
         }
     }
+
     func updateScanState() {
         scanStateHandler.send(centralManager.isScanning)
     }

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -59,7 +59,9 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     
     func cancel() {
         centralManager.stopScan()
-        restartTimer!.invalidate()
+        if let timer = restartTimer {
+            timer.invalidate()
+        }
         updateScanState()
     }
     

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -43,21 +43,11 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
             return
         }
         
-        centralManager.scanForPeripherals(
-            withServices: nil,
-            options: [
-                CBCentralManagerScanOptionAllowDuplicatesKey: true,
-            ]
-        )
+        scanForPeripherals()
         if scanPriority == .high {
             restartTimer = Timer.scheduledTimer(withTimeInterval: restartIntervalSec, repeats: true) { timer in
                 self.centralManager.stopScan()
-                self.centralManager.scanForPeripherals(
-                    withServices: [BluetoothScanner.serviceUUID],
-                    options: [
-                        CBCentralManagerScanOptionAllowDuplicatesKey: false,
-                    ]
-                )
+                self.scanForPeripherals()
             }
         }
         updateScanState()
@@ -103,6 +93,15 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String : Any], rssi RSSI: NSNumber) {
         handleOdidMessage(advertisementData: advertisementData, didDiscover: peripheral, rssi: RSSI, offset: 6)
+    }
+
+    private func scanForPeripherals(){
+        centralManager.scanForPeripherals(
+            withServices: [BluetoothScanner.serviceUUID],
+            options: [
+                CBCentralManagerScanOptionAllowDuplicatesKey: true,
+            ]
+        )    
     }
 
     private func handleOdidMessage(advertisementData: [String : Any], didDiscover peripheral: CBPeripheral, rssi RSSI: NSNumber, offset: NSNumber){

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -12,7 +12,7 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate {
     private let dataParser: OdidParser
     
     private var centralManager: CBCentralManager!
-    var autoRestart: Bool = false
+    
     let dispatchQueue: DispatchQueue = DispatchQueue(label: "BluetoothScanner")
     
     static let serviceUUID = CBUUID(string: "0000fffa-0000-1000-8000-00805f9b34fb")

--- a/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
@@ -72,13 +72,9 @@ public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
         // wifi not used on ios so far
     }
     
-    public func setAutorestartBluetooth(_ enable: NSNumber?) async -> FlutterError? {
-        bluetoothScanner?.autoRestart = enable as! Bool
+    public func setBtScanPriorityPriority(_ priority: DTGScanPriority) async -> FlutterError? {
+        bluetoothScanner.setScanPriority(priority: priority)
         return nil
-    }
-    
-    public func setAutorestartBluetoothEnable(_ enable: NSNumber?, completion: @escaping (FlutterError?) -> Void) {
-        bluetoothScanner?.autoRestart = enable as! Bool
     }
     
     public func isScanningBluetooth() async -> (NSNumber?, FlutterError?) {

--- a/ios/Classes/pigeon.h
+++ b/ios/Classes/pigeon.h
@@ -18,6 +18,11 @@ typedef NS_ENUM(NSUInteger, DTGMessageType) {
   DTGMessageTypeMessagePack = 6,
 };
 
+typedef NS_ENUM(NSUInteger, DTGScanPriority) {
+  DTGScanPriorityHigh = 0,
+  DTGScanPriorityLow = 1,
+};
+
 typedef NS_ENUM(NSUInteger, DTGMessageSource) {
   DTGMessageSourceBluetoothLegacy = 0,
   DTGMessageSourceBluetoothLongRange = 1,
@@ -361,7 +366,7 @@ NSObject<FlutterMessageCodec> *DTGApiGetCodec(void);
 - (void)startScanWifiWithCompletion:(void(^)(FlutterError *_Nullable))completion;
 - (void)stopScanBluetoothWithCompletion:(void(^)(FlutterError *_Nullable))completion;
 - (void)stopScanWifiWithCompletion:(void(^)(FlutterError *_Nullable))completion;
-- (void)setAutorestartBluetoothEnable:(NSNumber *)enable completion:(void(^)(FlutterError *_Nullable))completion;
+- (void)setBtScanPriorityPriority:(DTGScanPriority)priority completion:(void(^)(FlutterError *_Nullable))completion;
 - (void)isScanningBluetoothWithCompletion:(void(^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)isScanningWifiWithCompletion:(void(^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)bluetoothStateWithCompletion:(void(^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;

--- a/ios/Classes/pigeon.m
+++ b/ios/Classes/pigeon.m
@@ -598,15 +598,15 @@ void DTGApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<DTGApi> *a
   {
     FlutterBasicMessageChannel *channel =
       [[FlutterBasicMessageChannel alloc]
-        initWithName:@"dev.flutter.pigeon.Api.setAutorestartBluetooth"
+        initWithName:@"dev.flutter.pigeon.Api.setBtScanPriority"
         binaryMessenger:binaryMessenger
         codec:DTGApiGetCodec()        ];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(setAutorestartBluetoothEnable:completion:)], @"DTGApi api (%@) doesn't respond to @selector(setAutorestartBluetoothEnable:completion:)", api);
+      NSCAssert([api respondsToSelector:@selector(setBtScanPriorityPriority:completion:)], @"DTGApi api (%@) doesn't respond to @selector(setBtScanPriorityPriority:completion:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
         NSArray *args = message;
-        NSNumber *arg_enable = GetNullableObjectAtIndex(args, 0);
-        [api setAutorestartBluetoothEnable:arg_enable completion:^(FlutterError *_Nullable error) {
+        DTGScanPriority arg_priority = [GetNullableObjectAtIndex(args, 0) integerValue];
+        [api setBtScanPriorityPriority:arg_priority completion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
         }];
       }];

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -116,8 +116,8 @@ class FlutterOpenDroneId {
     _systemDataMessagesSubscription?.cancel();
   }
 
-  static Future<void> enableAutoRestart({required bool enable}) async {
-    await _api.setAutorestartBluetooth(enable);
+  static Future<void> setBtScanPriority(pigeon.ScanPriority priority) async {
+    await _api.setBtScanPriority(priority);
   }
 
   static Future<bool> get isScanningBluetooth async {

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -17,6 +17,11 @@ enum MessageType {
   MessagePack,
 }
 
+enum ScanPriority {
+  High,
+  Low,
+}
+
 enum MessageSource {
   BluetoothLegacy,
   BluetoothLongRange,
@@ -705,11 +710,11 @@ class Api {
     }
   }
 
-  Future<void> setAutorestartBluetooth(bool arg_enable) async {
+  Future<void> setBtScanPriority(ScanPriority arg_priority) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.Api.setAutorestartBluetooth', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.Api.setBtScanPriority', codec, binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
-        await channel.send(<Object?>[arg_enable]) as Map<Object?, Object?>?;
+        await channel.send(<Object?>[arg_priority.index]) as Map<Object?, Object?>?;
     if (replyMap == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/pigeon/schema.dart
+++ b/pigeon/schema.dart
@@ -11,6 +11,11 @@ enum MessageType {
   MessagePack,
 }
 
+enum ScanPriority {
+  High,
+  Low,
+}
+
 /// ODID Message Source
 enum MessageSource {
   BluetoothLegacy,
@@ -315,7 +320,7 @@ abstract class Api {
   @async
   void stopScanWifi();
   @async
-  void setAutorestartBluetooth(bool enable);
+  void setBtScanPriority(ScanPriority priority);
   @async
   bool isScanningBluetooth();
   @async


### PR DESCRIPTION
Add method to set scan priority to platform API. On Android, set ScanMode according to priority. On ios, implement timer that periodically restarts scan to maintain high priority.

Also removes unused autoRestart member variable