### PR TITLE
Feature: check bluetooth permissions

### DIFF
--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_opendroneid/models/permission_missing_exception.dart';
+import 'package:flutter_opendroneid/models/permissions_missing_exception.dart';
 import 'models/message_pack.dart';
 
 import 'package:permission_handler/permission_handler.dart';
@@ -106,12 +106,12 @@ class FlutterOpenDroneId {
     });
     if (usedTechnologies == UsedTechnologies.Bluetooth ||
         usedTechnologies == UsedTechnologies.Both) {
-      await _ensureBluetoothPermissions();
+      await _assertBluetoothPermissions();
       await _api.startScanBluetooth();
     }
     if (usedTechnologies == UsedTechnologies.Wifi ||
         usedTechnologies == UsedTechnologies.Both) {
-      await _ensureWifiPermissions();
+      await _assertWifiPermissions();
       await _api.startScanWifi();
     }
   }
@@ -132,10 +132,9 @@ class FlutterOpenDroneId {
     await _api.setBtScanPriority(priority);
   }
 
-  /// Makes sure that all necessary permissions are granted, used before
-  /// performing any Bluetooth activity
-  /// Throws PermissionMissingException if required permissions were not granted
-  static Future<void> _ensureBluetoothPermissions() async {
+  /// Checks all required Bluetooth permissions and throws
+  /// [PermissionsMissingException] if any of them are not granted.
+  static Future<void> _assertBluetoothPermissions() async {
     if (!await Permission.bluetooth.status.isGranted)
       throw PermissionMissingException('Bluetooth permission was not granted');
     // Android < 12 requires location permission to scan BT devices
@@ -155,12 +154,9 @@ class FlutterOpenDroneId {
     }
   }
 
-  /// Makes sure that all necessary permissions are granted, used before
-  /// performing any Wi-Fi activity
-  ///
-  /// Throws PermissionMissingException if required
-  /// permissions were not granted
-  static Future<void> _ensureWifiPermissions() async {
+  /// Checks all required Wi-Fi permissions and throws
+  /// [PermissionsMissingException] if any of them are not granted.
+  static Future<void> _assertWifiPermissions() async {
     // Android requires location permission to scan Wi-Fi devices
     if (Platform.isAndroid && !await Permission.location.status.isGranted) {
       throw PermissionMissingException('Location permission is required '

--- a/lib/models/permission_missing_exception.dart
+++ b/lib/models/permission_missing_exception.dart
@@ -1,5 +1,0 @@
-class PermissionMissingException implements Exception {
-  final String description;
-
-  PermissionMissingException(this.description);
-}

--- a/lib/models/permission_missing_exception.dart
+++ b/lib/models/permission_missing_exception.dart
@@ -1,0 +1,5 @@
+class PermissionMissingException implements Exception {
+  final String description;
+
+  PermissionMissingException(this.description);
+}

--- a/lib/models/permissions_missing_exception.dart
+++ b/lib/models/permissions_missing_exception.dart
@@ -1,5 +1,6 @@
-class PermissionsMissingException implements Exception {
-  final String description;
+import 'package:permission_handler/permission_handler.dart';
 
-  PermissionsMissingException(this.description);
+class PermissionsMissingException implements Exception {
+  final List<Permission> missingPermissions;
+  PermissionsMissingException(this.missingPermissions);
 }

--- a/lib/models/permissions_missing_exception.dart
+++ b/lib/models/permissions_missing_exception.dart
@@ -1,0 +1,5 @@
+class PermissionsMissingException implements Exception {
+  final String description;
+
+  PermissionsMissingException(this.description);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   pigeon: ^3.2.7
+  permission_handler: ^9.2.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   pigeon: ^3.2.7
   permission_handler: ^9.2.0
+  device_info_plus: ^3.2.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Request permissions before starting scans

iOS requires just bluetooth permissions. 
Android requires bluetooth, bluetoothScan and location for bt scanning. I tested scanning without location permission on Android 9 and 12  and it seems that it is required on both versions, because I did not get any data with location disabled.

Location is also required for [Wi-Fi scanning on Android.](https://developer.android.com/guide/topics/connectivity/wifi-scan)