### PR TITLE
feature: check new android 13 Wi-Fi permission

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -9,4 +9,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS"/>
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation" />
 </manifest>

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -170,7 +170,7 @@ class FlutterOpenDroneId {
       if (androidVersionNumber == null) return;
       // Android < 12 also requires location permission
       // Android 13 has a new nearbyWifiDevicesPermission
-      if (androidVersionNumber! >= 13) {
+      if (androidVersionNumber >= 13) {
         if (!await Permission.nearbyWifiDevices.status.isGranted)
           missingPermissions.add(Permission.nearbyWifiDevices);
       } else {

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -146,9 +146,7 @@ class FlutterOpenDroneId {
       if (!await Permission.bluetoothScan.status.isGranted)
         missingPermissions.add(Permission.bluetoothScan);
 
-      final deviceInfo = DeviceInfoPlugin();
-      final androidVersion = (await deviceInfo.androidInfo).version.release;
-      final androidVersionNumber = int.tryParse(androidVersion ?? '');
+      final androidVersionNumber = await getAndroidVersionNumber();
 
       // Android < 12 also requires location permission to scan BT devices
       if (androidVersionNumber != null && androidVersionNumber < 12) {
@@ -165,9 +163,29 @@ class FlutterOpenDroneId {
   /// [PermissionsMissingException] if any of them are not granted.
   static Future<void> _assertWifiPermissions() async {
     // Android requires location permission to scan Wi-Fi devices
-    if (Platform.isAndroid && !await Permission.location.status.isGranted) {
-      throw PermissionsMissingException([Permission.location]);
+    if (Platform.isAndroid) {
+      List<Permission> missingPermissions = [];
+
+      final androidVersionNumber = await getAndroidVersionNumber();
+      if (androidVersionNumber == null) return;
+      // Android < 12 also requires location permission
+      // Android 13 has a new nearbyWifiDevicesPermission
+      if (androidVersionNumber! >= 13) {
+        if (!await Permission.nearbyWifiDevices.status.isGranted)
+          missingPermissions.add(Permission.nearbyWifiDevices);
+      } else {
+        if (!await Permission.location.status.isGranted)
+          missingPermissions.add(Permission.location);
+      }
+      if (missingPermissions.isNotEmpty)
+        throw PermissionsMissingException(missingPermissions);
     }
+  }
+
+  static Future<int?> getAndroidVersionNumber() async {
+    final deviceInfo = DeviceInfoPlugin();
+    final androidVersion = (await deviceInfo.androidInfo).version.release;
+    return int.tryParse(androidVersion);
   }
 
   static Future<bool> get isScanningBluetooth async {


### PR DESCRIPTION
Android 13 introduces new _nearbyWifiDevices_ permission ,it replaces need to have location permission for Wi-Fi scans.