### PR TITLE
fix: require loc permission for bt scan on Android

### DIFF
--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -146,13 +146,10 @@ class FlutterOpenDroneId {
       if (!await Permission.bluetoothScan.status.isGranted)
         missingPermissions.add(Permission.bluetoothScan);
 
-      final androidVersionNumber = await getAndroidVersionNumber();
+      // Android also requires location permission to scan BT devices
 
-      // Android < 12 also requires location permission to scan BT devices
-      if (androidVersionNumber != null && androidVersionNumber < 12) {
-        if (!await Permission.location.status.isGranted)
-          missingPermissions.add(Permission.location);
-      }
+      if (!await Permission.location.status.isGranted)
+        missingPermissions.add(Permission.location);
     }
 
     if (missingPermissions.isNotEmpty)


### PR DESCRIPTION
Throw `PermissionMissingException` when starting Bluetooth scans without location permission on Android.

Android requires location permission for bt scanning for Android SDK 33.

We can go around it by asserting ['neverForLocation' flag](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions#assert-never-for-location), but some data may be filtered out, so I decided we would require location for Bluetooth scanning.

User must select "while using the app" option when asked about location usage in order for scans to work when app is in background.