### PR TITLE
De-duplicate data using fields comparison

### DIFF
--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_opendroneid/models/compare_extension.dart';
 import 'package:flutter_opendroneid/models/permissions_missing_exception.dart';
 import 'models/message_pack.dart';
 
@@ -207,6 +208,10 @@ class FlutterOpenDroneId {
           lastUpdate:
               DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp),
         );
+    if (storedPack.basicIdMessage != null &&
+        storedPack.basicIdMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithBasic(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }
@@ -218,6 +223,11 @@ class FlutterOpenDroneId {
             macAddress: mac,
             lastUpdate:
                 DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp));
+    // skip location updates with same timestamp
+    if (storedPack.locationValid() &&
+        storedPack.locationMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithLocation(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }
@@ -229,6 +239,10 @@ class FlutterOpenDroneId {
             macAddress: mac,
             lastUpdate:
                 DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp));
+    if (storedPack.operatorIDValid() &&
+        storedPack.operatorIdMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithOperatorId(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }
@@ -240,6 +254,10 @@ class FlutterOpenDroneId {
             macAddress: mac,
             lastUpdate:
                 DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp));
+    if (storedPack.systemDataValid() &&
+        storedPack.systemDataMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithSystemData(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }
@@ -253,6 +271,11 @@ class FlutterOpenDroneId {
             macAddress: mac,
             lastUpdate:
                 DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp));
+    // skip location updates with same timestamp
+    if (storedPack.authenticationMessage != null &&
+        storedPack.authenticationMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithAuthentication(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }
@@ -265,6 +288,11 @@ class FlutterOpenDroneId {
           lastUpdate:
               DateTime.fromMillisecondsSinceEpoch(message.receivedTimestamp),
         );
+    // skip location updates with same timestamp
+    if (storedPack.selfIdMessage != null &&
+        storedPack.selfIdMessage!.containsEqualData(message)) {
+      return;
+    }
     _storedPacks[mac] = storedPack.updateWithSelfId(message);
     _packController.add(_storedPacks[message.macAddress]!);
   }

--- a/lib/models/compare_extension.dart
+++ b/lib/models/compare_extension.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_opendroneid/pigeon.dart';
+
+// extensions to check whether messages have the same data
+// The messages may not necessarily be the same, timestamp, rssi are ignored
+// compares just relevant data fields
+extension LocationCompareExtension on LocationMessage {
+  // consider location  with same timestamp equal
+  bool containsEqualData(LocationMessage other) {
+    return time == other.time &&
+        latitude == other.latitude &&
+        longitude == other.longitude;
+  }
+}
+
+extension BasicIdCompareExtension on BasicIdMessage {
+  bool containsEqualData(BasicIdMessage other) {
+    return uasId == other.uasId &&
+        idType == other.idType &&
+        uaType == other.uaType;
+  }
+}
+
+extension OperatorIdCompareExtension on OperatorIdMessage {
+  bool containsEqualData(OperatorIdMessage other) {
+    return operatorId == other.operatorId;
+  }
+}
+
+extension SystemDataCompareExtension on SystemDataMessage {
+  bool containsEqualData(SystemDataMessage other) {
+    return areaCeiling == other.areaCeiling &&
+        areaCount == other.areaCount &&
+        areaFloor == other.areaFloor &&
+        areaRadius == other.areaRadius &&
+        category == other.category &&
+        classValue == other.classValue &&
+        classificationType == other.classificationType &&
+        operatorAltitudeGeo == other.operatorAltitudeGeo &&
+        operatorLatitude == other.operatorLatitude &&
+        operatorLocationType == other.operatorLocationType &&
+        operatorLongitude == other.operatorLongitude;
+  }
+}
+
+extension AuthenticationCompareExtension on AuthenticationMessage {
+  bool containsEqualData(AuthenticationMessage other) {
+    return authData == other.authData &&
+        authDataPage == other.authDataPage &&
+        authLastPageIndex == other.authLastPageIndex &&
+        authLength == other.authLength &&
+        authTimestamp == other.authTimestamp &&
+        authType == other.authType;
+  }
+}
+
+extension SelfIdCompareExtension on SelfIdMessage {
+  bool containsEqualData(SelfIdMessage other) {
+    return descriptionType == other.descriptionType &&
+        operationDescription == other.operationDescription;
+  }
+}


### PR DESCRIPTION
Do not update pack if pack already contains the same data as new message, e.g. same location with same timestamp.
I included all message types, so e.g. when BasicId comes with same uasId, pack is not updated.

This improves performance, but lowers the number of messages processed, so e.g. rssi is not updated as often so this information can be outdated. Maybe we should use this just for location, I will leave it for discussion.