### PR TITLE
chore: bump Android SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,14 +25,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
     }
     kotlinOptions {
         jvmTarget = '1.8'


### PR DESCRIPTION
Bump `targetSDKVersion` and `compileSDKVersion` to 33.