### PR TITLE
Re-exported Dart ODID types

### DIFF
--- a/lib/extensions/compare_extension.dart
+++ b/lib/extensions/compare_extension.dart
@@ -1,4 +1,4 @@
-import 'package:dart_opendroneid/src/types.dart';
+import 'package:dart_opendroneid/dart_opendroneid.dart';
 
 // extensions to check whether messages have the same data
 // The messages may not necessarily be the same, timestamp, rssi are ignored

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -10,6 +10,8 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter_opendroneid/pigeon.dart' as pigeon;
 
+export 'package:dart_opendroneid/src/types.dart';
+
 enum UsedTechnologies { Wifi, Bluetooth, Both, None }
 
 class FlutterOpenDroneId {

--- a/lib/models/message_container.dart
+++ b/lib/models/message_container.dart
@@ -1,7 +1,7 @@
+import 'package:dart_opendroneid/dart_opendroneid.dart';
+import 'package:flutter_opendroneid/extensions/compare_extension.dart';
 import 'package:flutter_opendroneid/models/constants.dart';
 import 'package:flutter_opendroneid/pigeon.dart' as pigeon;
-import 'package:dart_opendroneid/src/types.dart';
-import 'package:flutter_opendroneid/extensions/compare_extension.dart';
 
 /// The [MessageContainer] groups together messages of different types
 /// from one device. It contains one instance of each message. The container is

--- a/lib/utils/conversions.dart
+++ b/lib/utils/conversions.dart
@@ -1,6 +1,4 @@
-import 'package:dart_opendroneid/src/types.dart';
-import 'package:dart_opendroneid/src/types/uas_id.dart';
-import 'package:dart_opendroneid/src/types/ua_classification.dart';
+import 'package:dart_opendroneid/dart_opendroneid.dart';
 import 'package:flutter_opendroneid/extensions/list_extension.dart';
 
 /// Conversions extensions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   permission_handler: ^10.2.0 
   device_info_plus: ^8.0.0
-  dart_opendroneid: ^0.2.6
+  dart_opendroneid: ^0.3.0
 
 dev_dependencies:
   pigeon: ^10.1.6


### PR DESCRIPTION
Added re-export for `dart-opendroneid` types to `flutter-opendroneid`, so that the types can be used from apps without the need to depend on `dart-opendroneid` directly.

Please wait for https://github.com/dronetag/dart-opendroneid/pull/2 to be merged and bump `dart-opendroneid` version in this PR.

DT-2637