### PR TITLE
Upgraded outdated packages and fixed Gradle issues

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  FLUTTER_VERSION: '3.13.x'
+  FLUTTER_VERSION: '3.16.7'
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  FLUTTER_VERSION: "3.13.x"
+  FLUTTER_VERSION: "3.16.7"
 
 jobs:
   integration:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The architecture of native code is inspired by [OpenDroneID Android receiver app
 
 ## Pre-requisities
 
-- Flutter 3.10.0 or newer
+- Flutter 3.16.7 or newer
 
 ## Getting Started
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.4.30'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,11 +32,13 @@ android {
         minSdkVersion 21
         targetSdkVersion 33
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-}
+dependencies {}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,15 +2,14 @@ group 'cz.dronetag.flutter_opendroneid'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.4.30'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.android.tools.build:gradle:$agpVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,12 +24,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
+        compileSdk 33
         minSdkVersion 21
         targetSdkVersion 33
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+kotlinVersion=1.8.21
+agpVersion=7.4.2

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Fri Feb 02 14:52:12 SGT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  permission_handler: ^11.0.1
-  device_info_plus: ^8.0.0
-  dart_opendroneid: ^0.3.0
+  permission_handler: ^11.2.0
+  device_info_plus: ^9.1.2
+  dart_opendroneid: ^0.4.0
 
 dev_dependencies:
   pigeon: ^10.1.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/dronetag/flutter-opendroneid
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.16.7"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Upgraded Gradle to 7.6.3, unified configuration so it is consistent with our other packages and fixed a few issues due to outdated Gradle config.

Bumped `pubspec.yaml` dependencies.

Bumped Flutter CI to 3.16.7

