### PR TITLE
Pubspec lock now not enforced

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,7 @@ jobs:
         uses: dronetag/gha-shared/.github/actions/flutter-install@master
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          enforce-lockfile: false
       - name: Run code analysis
         run: flutter analyze --no-fatal-infos
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
         uses: dronetag/gha-shared/.github/actions/flutter-install@master
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          enforce-lockfile: false
       - uses: dronetag/gha-shared/.github/actions/update-pubspec-version@master
         with:
           version: ${{ needs.release-version.outputs.version }}


### PR DESCRIPTION
Standard Dronetag Flutter pipeline now enforces `pubspec.lock` unless explicitly disabled. Since `pubspec.lock` is not shared for libraries, this PR disables the enforcement.