### PR TITLE
Separated release and publish CI step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,5 @@ jobs:
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           enforce-lockfile: false
-      - uses: dronetag/gha-shared/.github/actions/update-pubspec-version@master
-        with:
-          version: ${{ needs.release-version.outputs.version }}
       - name: Publish to pub.dev
         run: flutter pub publish -f

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,10 @@
 name: Publish to pub.dev
 
-# Publish workflow checks out specified release tag and publishes
-# the library to pub.dev
-
+# Publish is triggered on new version tag push event
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to release (e.g. "v2.31.0")'
-        required: true
-        type: string
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+*' # for tags like: 'v1.2.3'
 
 env:
   FLUTTER_VERSION: "3.16.7"
@@ -21,11 +16,8 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      # TODO check for successful release with tag ${{ inputs.version }}
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.version }}
       - name: Install the project
         uses: dronetag/gha-shared/.github/actions/flutter-install@master
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,45 +1,36 @@
 name: Publish to pub.dev
 
-# Publish workflow releases a new version, updates changelog
-# and publishes the library to pub.dev
+# Publish workflow checks out specified release tag and publishes
+# the library to pub.dev
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. "v2.31.0")'
+        required: true
+        type: string
 
 env:
   FLUTTER_VERSION: "3.16.7"
 
 jobs:
-  integration:
-    name: Run integration
-    uses: ./.github/workflows/integration.yml
-
-  release-version:
-    name: Release a new version
-    needs: integration
-    uses: dronetag/gha-shared/.github/workflows/create-release.yml@master
-    concurrency: release-version-${{ github.repository }}
-    with:
-      install-changelog-plugin: true
-      must-release: true
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
     name: Publish to pub.dev
-    needs: release-version
     permissions:
       id-token: write
     runs-on: ubuntu-latest
     steps:
+      # TODO check for successful release with tag ${{ inputs.version }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.version }}
       - name: Install the project
         uses: dronetag/gha-shared/.github/actions/flutter-install@master
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          setup-java: false
           enforce-lockfile: false
       - name: Publish to pub.dev
         run: flutter pub publish -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Create Github release
+
+# Release workflow creates a new Github release
+# with new version and updates changelog
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  FLUTTER_VERSION: "3.16.7"
+
+jobs:
+  integration:
+    name: Run integration
+    uses: ./.github/workflows/integration.yml
+
+  release-version:
+    name: Release a new version
+    needs: integration
+    uses: dronetag/gha-shared/.github/workflows/create-release.yml@master
+    concurrency: release-version-${{ github.repository }}
+    with:
+      install-changelog-plugin: true
+      install-yq: true
+      must-release: true
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,15 @@ env:
 
 jobs:
   integration:
+    # Prevent release commits from triggering integration check
+    if: "!contains(github.event.head_commit.message, 'chore(release)')"
     name: Run integration
     uses: ./.github/workflows/integration.yml
 
   release-version:
-    name: Release a new version
+    # Prevent release commits from triggering release again
+    if: "!contains(github.event.head_commit.message, 'chore(release)')"
+    name: Release new version
     needs: integration
     uses: dronetag/gha-shared/.github/workflows/create-release.yml@master
     concurrency: release-version-${{ github.repository }}
@@ -27,4 +31,4 @@ jobs:
       must-release: false
       create-github-release: false # Release performed by semantic-release
     secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+      github-token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     with:
       install-changelog-plugin: true
       install-yq: true
-      must-release: true
+      must-release: false
+      create-github-release: false # Release performed by semantic-release
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -64,6 +64,12 @@
         ],
         "message": "chore(release): Release ${nextRelease.version}\n\n${nextRelease.notes}"
       }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "failComment": false
+      }
     ]
   ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -50,11 +50,19 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "yq -i '.version = \"${nextRelease.version}\"' pubspec.yaml"
+      }
+    ],
+    [
       "@semantic-release/git",
       {
         "assets": [
-          "CHANGELOG.md"
-        ]
+          "CHANGELOG.md",
+          "pubspec.yaml"
+        ],
+        "message": "chore(release): Release ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ]
   ]


### PR DESCRIPTION
Separated release and publish CI pipeline into two steps:
- release - runs on every commit to `master`, except for `chore(release)` commits done by `semantic-release`
- publish - runs on every version tag push

Release is now entirely handled by `semantic-release`. New version is calculated, changelog is generated, `pubspec.yaml` updated, new version tag is pushed and finally a Github release is created.

To trigger the publish pipeline from another Github Action (in this case the release action), the version tag push must be done using PAT (personal access token) of a user, not using the pipeline token. The release pipeline expects `secrets.RELEASE_PAT` to be present.