### PR TITLE
Added missing wifi state receiver unregistration on cancel

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
@@ -108,6 +108,7 @@ class WifiNaNScanner (
     override fun cancel() {
         if (!wifiAwareSupported) return
         isScanning = false;
+        context.unregisterReceiver(adapterStateReceiver)
         stopScan()
     }
 

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
@@ -80,6 +80,7 @@ class WifiScanner (
 
     override fun cancel() {
         isScanning = false;
+        context.unregisterReceiver(broadcastReceiver)
         wifiStateHandler.send(false)
         if (countDownTimer != null) {
             countDownTimer!!.cancel();


### PR DESCRIPTION
Wifi adapter state receiver which is registered when wifi scanner is started was not unregistered upon `cancel()` call. When app was sent to background and receiver tried to handle incoming message an exception was raised because of missing background location permissions.

Receiver is now unregistered when scanning is cancelled.