### PR TITLE
fix: pass rssi to update method when receiving message pack

### DIFF
--- a/lib/models/message_container.dart
+++ b/lib/models/message_container.dart
@@ -76,6 +76,7 @@ class MessageContainer {
           message: packMessage,
           receivedTimestamp: receivedTimestamp,
           source: source,
+          rssi: rssi,
         );
         if (update != null) result = update;
       }


### PR DESCRIPTION
Add missing rssi parameter in `messageContainer.update ` call when receiving `MessagePack`.