### PR TITLE
fix: solve exception when stopping Wi-Fi scans

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
@@ -92,14 +92,9 @@ class WifiNaNScanner (
     }
 
     override fun scan() {
+        if (!wifiAwareSupported) return
+        
         isScanning = true
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
-            !context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI_AWARE)) {
-            Log.i(TAG, "WiFi Aware is not supported.");
-            wifiAwareSupported = false
-            return;
-        }
-        wifiAwareSupported = true
         context.registerReceiver(adapterStateReceiver, IntentFilter(WifiAwareManager.ACTION_WIFI_AWARE_STATE_CHANGED))
         startScan();
     }
@@ -107,6 +102,7 @@ class WifiNaNScanner (
     @RequiresApi(Build.VERSION_CODES.O)
     override fun cancel() {
         if (!wifiAwareSupported) return
+        
         isScanning = false;
         context.unregisterReceiver(adapterStateReceiver)
         stopScan()


### PR DESCRIPTION
Resolve exception that occured when attempting to stop Wi-Fi scans. It occurred only on phones what support Wi-Fi Beacon but not Wi-Fi NaN, e.g. Huawei that we have in SW.

Method that starts Wi-Fi NaN scan wrongly set `isScanning` to `true` before check if NaN is supported, then when stopping scans it crashed.

Return early from scan method if `wifiAwareSupported` is false.

DT-3337

Fixes [APP-2MY](https://sentry.dronetag.cz/organizations/dronetag/issues/4899/).