### PR TITLE
refactor: split message event channels for wifi and bt

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
@@ -24,13 +24,14 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
     private lateinit var context: Context
     private lateinit var activity: Activity
 
-    private val odidPayloadStreamHandler = StreamHandler()
+    private val bluetoothOdidPayloadStreamHandler = StreamHandler()
+    private val wifiOdidPayloadStreamHandler = StreamHandler()
     private val bluetoothStateStreamHandler = StreamHandler()
     private val wifiStateStreamHandler = StreamHandler()
 
     private var scanner: BluetoothScanner =
             BluetoothScanner(
-                    odidPayloadStreamHandler, bluetoothStateStreamHandler,
+                bluetoothOdidPayloadStreamHandler, bluetoothStateStreamHandler,
             )
     private lateinit var wifiScanner: WifiScanner
     private lateinit var wifiNaNScanner: WifiNaNScanner
@@ -44,9 +45,10 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
         StreamHandler.bindMultipleHandlers(
                 flutterPluginBinding.binaryMessenger,
                 mapOf(
-                    "flutter_odid_data" to odidPayloadStreamHandler,
-                    "flutter_odid_bt_state" to bluetoothStateStreamHandler,
-                    "flutter_odid_wifi_state" to wifiStateStreamHandler
+                    "flutter_odid_data_bt" to bluetoothOdidPayloadStreamHandler,
+                    "flutter_odid_data_wifi" to wifiOdidPayloadStreamHandler,
+                    "flutter_odid_state_bt" to bluetoothStateStreamHandler,
+                    "flutter_odid_state_wifi" to wifiStateStreamHandler
                 )
         )
 
@@ -60,11 +62,11 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
 
         wifiScanner =
                 WifiScanner(
-                        odidPayloadStreamHandler, wifiStateStreamHandler, wifiManager, context
+                    wifiOdidPayloadStreamHandler, wifiStateStreamHandler, wifiManager, context
                 )
         wifiNaNScanner =
                 WifiNaNScanner(
-                        odidPayloadStreamHandler, wifiStateStreamHandler, wifiAwareManager, context
+                    wifiOdidPayloadStreamHandler, wifiStateStreamHandler, wifiAwareManager, context
                 )
     }
 
@@ -97,9 +99,10 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
         StreamHandler.clearMultipleHandlers(
             binding.binaryMessenger,
             listOf(
-                "flutter_odid_data",
-                "flutter_odid_bt_state",
-                "flutter_odid_wifi_state",
+                "flutter_odid_data_bt",
+                "flutter_odid_data_wifi",
+                "flutter_odid_state_bt",
+                "flutter_odid_state_wifi",
             )
         )
     }

--- a/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
@@ -3,14 +3,15 @@ import UIKit
 
 @available(iOS 13.0.0, *)
 public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
+    private static let dataEventChannelName = "flutter_odid_data_bt"
+    private static let stateEventChannelName = "flutter_odid_state_bt"
     private static var eventChannels: [String: FlutterEventChannel] = [:]
 
     private var bluetoothScanner: BluetoothScanner!
 
     private let streamHandlers: [String: StreamHandler] = [
-        "flutter_odid_data": StreamHandler(),
-        "flutter_odid_bt_state": StreamHandler(),
-        "flutter_odid_wifi_state": StreamHandler()
+        dataEventChannelName: StreamHandler(),
+        stateEventChannelName: StreamHandler(),
     ]
     
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -20,9 +21,8 @@ public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
         
         // Register event channels
         eventChannels = [
-            "flutter_odid_data": FlutterEventChannel(name: "flutter_odid_data", binaryMessenger: registrar.messenger()),
-            "flutter_odid_bt_state": FlutterEventChannel(name: "flutter_odid_bt_state", binaryMessenger: registrar.messenger()),
-            "flutter_odid_wifi_state": FlutterEventChannel(name: "flutter_odid_wifi_state", binaryMessenger: registrar.messenger()),
+            dataEventChannelName: FlutterEventChannel(name: dataEventChannelName, binaryMessenger: registrar.messenger()),
+            stateEventChannelName: FlutterEventChannel(name: stateEventChannelName, binaryMessenger: registrar.messenger()),
         ]
         
         // Register stream handlers
@@ -34,8 +34,8 @@ public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
         
         // Register bluetooth scanner
         instance.bluetoothScanner = BluetoothScanner(
-            odidPayloadStreamHandler: instance.streamHandlers["flutter_odid_data"]!,
-            scanStateHandler: instance.streamHandlers["flutter_odid_bt_state"]!
+            odidPayloadStreamHandler: instance.streamHandlers[dataEventChannelName]!,
+            scanStateHandler: instance.streamHandlers[stateEventChannelName]!
         )
     
         registrar.addApplicationDelegate(instance)

--- a/lib/models/dri_source_type.dart
+++ b/lib/models/dri_source_type.dart
@@ -1,0 +1,1 @@
+enum DriSourceType { Wifi, Bluetooth }


### PR DESCRIPTION
Refactor FlutterOpendroneId API for the DroneScanner 2.0.

I created 2 event channels, one for bt and one for wifi. Now there are 2 streams, 1 for each technology. 
I also refactored start/stop methods, so it is possible to control wifi/bt separately.