### PR TITLE
Implemented `copyWith` for `ReceivedODIDMessage`

### DIFF
--- a/lib/models/received_odid_message.dart
+++ b/lib/models/received_odid_message.dart
@@ -18,6 +18,22 @@ class ReceivedODIDMessage {
     this.rssi,
   });
 
+  ReceivedODIDMessage copyWith({
+    ODIDMessage? odidMessage,
+    DateTime? receivedTimestamp,
+    MessageSource? source,
+    MacAddress? macAddress,
+    int? rssi,
+  }) {
+    return ReceivedODIDMessage(
+      odidMessage: odidMessage ?? this.odidMessage,
+      receivedTimestamp: receivedTimestamp ?? this.receivedTimestamp,
+      source: source ?? this.source,
+      macAddress: macAddress ?? this.macAddress,
+      rssi: rssi ?? this.rssi,
+    );
+  }
+
   @override
   String toString() => 'ReceivedODIDMessage{ '
       'odidMessage type: ${odidMessage.runtimeType}, '


### PR DESCRIPTION
Added `copyWith` implementation for `ReceivedODIDMessage` to allow easier manipulation with the container elsewhere. If it was omitted intentionally I can also implement it in the library using flutter-opendroneid.

DT-3744