### PR TITLE
Feat: add extended ODIDMetadata

### DIFF
--- a/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
+++ b/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
@@ -114,6 +114,261 @@ public class Pigeon {
     }
   }
 
+  public enum BluetoothPhy {
+    NONE(0),
+    PHY1M(1),
+    PHY2M(2),
+    PHY_LECODED(3),
+    UNKNOWN(4);
+
+    final int index;
+
+    private BluetoothPhy(final int index) {
+      this.index = index;
+    }
+  }
+
+  /** Generated class from Pigeon that represents data sent in messages. */
+  public static final class ODIDMetadata {
+    private @NonNull String macAddress;
+
+    public @NonNull String getMacAddress() {
+      return macAddress;
+    }
+
+    public void setMacAddress(@NonNull String setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"macAddress\" is null.");
+      }
+      this.macAddress = setterArg;
+    }
+
+    private @NonNull MessageSource source;
+
+    public @NonNull MessageSource getSource() {
+      return source;
+    }
+
+    public void setSource(@NonNull MessageSource setterArg) {
+      if (setterArg == null) {
+        throw new IllegalStateException("Nonnull field \"source\" is null.");
+      }
+      this.source = setterArg;
+    }
+
+    private @Nullable Long rssi;
+
+    public @Nullable Long getRssi() {
+      return rssi;
+    }
+
+    public void setRssi(@Nullable Long setterArg) {
+      this.rssi = setterArg;
+    }
+
+    private @Nullable String btName;
+
+    public @Nullable String getBtName() {
+      return btName;
+    }
+
+    public void setBtName(@Nullable String setterArg) {
+      this.btName = setterArg;
+    }
+
+    private @Nullable Long frequency;
+
+    public @Nullable Long getFrequency() {
+      return frequency;
+    }
+
+    public void setFrequency(@Nullable Long setterArg) {
+      this.frequency = setterArg;
+    }
+
+    private @Nullable Long centerFreq0;
+
+    public @Nullable Long getCenterFreq0() {
+      return centerFreq0;
+    }
+
+    public void setCenterFreq0(@Nullable Long setterArg) {
+      this.centerFreq0 = setterArg;
+    }
+
+    private @Nullable Long centerFreq1;
+
+    public @Nullable Long getCenterFreq1() {
+      return centerFreq1;
+    }
+
+    public void setCenterFreq1(@Nullable Long setterArg) {
+      this.centerFreq1 = setterArg;
+    }
+
+    private @Nullable Long channelWidthMhz;
+
+    public @Nullable Long getChannelWidthMhz() {
+      return channelWidthMhz;
+    }
+
+    public void setChannelWidthMhz(@Nullable Long setterArg) {
+      this.channelWidthMhz = setterArg;
+    }
+
+    private @Nullable BluetoothPhy primaryPhy;
+
+    public @Nullable BluetoothPhy getPrimaryPhy() {
+      return primaryPhy;
+    }
+
+    public void setPrimaryPhy(@Nullable BluetoothPhy setterArg) {
+      this.primaryPhy = setterArg;
+    }
+
+    private @Nullable BluetoothPhy secondaryPhy;
+
+    public @Nullable BluetoothPhy getSecondaryPhy() {
+      return secondaryPhy;
+    }
+
+    public void setSecondaryPhy(@Nullable BluetoothPhy setterArg) {
+      this.secondaryPhy = setterArg;
+    }
+
+    /** Constructor is non-public to enforce null safety; use Builder. */
+    ODIDMetadata() {}
+
+    public static final class Builder {
+
+      private @Nullable String macAddress;
+
+      public @NonNull Builder setMacAddress(@NonNull String setterArg) {
+        this.macAddress = setterArg;
+        return this;
+      }
+
+      private @Nullable MessageSource source;
+
+      public @NonNull Builder setSource(@NonNull MessageSource setterArg) {
+        this.source = setterArg;
+        return this;
+      }
+
+      private @Nullable Long rssi;
+
+      public @NonNull Builder setRssi(@Nullable Long setterArg) {
+        this.rssi = setterArg;
+        return this;
+      }
+
+      private @Nullable String btName;
+
+      public @NonNull Builder setBtName(@Nullable String setterArg) {
+        this.btName = setterArg;
+        return this;
+      }
+
+      private @Nullable Long frequency;
+
+      public @NonNull Builder setFrequency(@Nullable Long setterArg) {
+        this.frequency = setterArg;
+        return this;
+      }
+
+      private @Nullable Long centerFreq0;
+
+      public @NonNull Builder setCenterFreq0(@Nullable Long setterArg) {
+        this.centerFreq0 = setterArg;
+        return this;
+      }
+
+      private @Nullable Long centerFreq1;
+
+      public @NonNull Builder setCenterFreq1(@Nullable Long setterArg) {
+        this.centerFreq1 = setterArg;
+        return this;
+      }
+
+      private @Nullable Long channelWidthMhz;
+
+      public @NonNull Builder setChannelWidthMhz(@Nullable Long setterArg) {
+        this.channelWidthMhz = setterArg;
+        return this;
+      }
+
+      private @Nullable BluetoothPhy primaryPhy;
+
+      public @NonNull Builder setPrimaryPhy(@Nullable BluetoothPhy setterArg) {
+        this.primaryPhy = setterArg;
+        return this;
+      }
+
+      private @Nullable BluetoothPhy secondaryPhy;
+
+      public @NonNull Builder setSecondaryPhy(@Nullable BluetoothPhy setterArg) {
+        this.secondaryPhy = setterArg;
+        return this;
+      }
+
+      public @NonNull ODIDMetadata build() {
+        ODIDMetadata pigeonReturn = new ODIDMetadata();
+        pigeonReturn.setMacAddress(macAddress);
+        pigeonReturn.setSource(source);
+        pigeonReturn.setRssi(rssi);
+        pigeonReturn.setBtName(btName);
+        pigeonReturn.setFrequency(frequency);
+        pigeonReturn.setCenterFreq0(centerFreq0);
+        pigeonReturn.setCenterFreq1(centerFreq1);
+        pigeonReturn.setChannelWidthMhz(channelWidthMhz);
+        pigeonReturn.setPrimaryPhy(primaryPhy);
+        pigeonReturn.setSecondaryPhy(secondaryPhy);
+        return pigeonReturn;
+      }
+    }
+
+    @NonNull
+    ArrayList<Object> toList() {
+      ArrayList<Object> toListResult = new ArrayList<Object>(10);
+      toListResult.add(macAddress);
+      toListResult.add(source == null ? null : source.index);
+      toListResult.add(rssi);
+      toListResult.add(btName);
+      toListResult.add(frequency);
+      toListResult.add(centerFreq0);
+      toListResult.add(centerFreq1);
+      toListResult.add(channelWidthMhz);
+      toListResult.add(primaryPhy == null ? null : primaryPhy.index);
+      toListResult.add(secondaryPhy == null ? null : secondaryPhy.index);
+      return toListResult;
+    }
+
+    static @NonNull ODIDMetadata fromList(@NonNull ArrayList<Object> list) {
+      ODIDMetadata pigeonResult = new ODIDMetadata();
+      Object macAddress = list.get(0);
+      pigeonResult.setMacAddress((String) macAddress);
+      Object source = list.get(1);
+      pigeonResult.setSource(source == null ? null : MessageSource.values()[(int) source]);
+      Object rssi = list.get(2);
+      pigeonResult.setRssi((rssi == null) ? null : ((rssi instanceof Integer) ? (Integer) rssi : (Long) rssi));
+      Object btName = list.get(3);
+      pigeonResult.setBtName((String) btName);
+      Object frequency = list.get(4);
+      pigeonResult.setFrequency((frequency == null) ? null : ((frequency instanceof Integer) ? (Integer) frequency : (Long) frequency));
+      Object centerFreq0 = list.get(5);
+      pigeonResult.setCenterFreq0((centerFreq0 == null) ? null : ((centerFreq0 instanceof Integer) ? (Integer) centerFreq0 : (Long) centerFreq0));
+      Object centerFreq1 = list.get(6);
+      pigeonResult.setCenterFreq1((centerFreq1 == null) ? null : ((centerFreq1 instanceof Integer) ? (Integer) centerFreq1 : (Long) centerFreq1));
+      Object channelWidthMhz = list.get(7);
+      pigeonResult.setChannelWidthMhz((channelWidthMhz == null) ? null : ((channelWidthMhz instanceof Integer) ? (Integer) channelWidthMhz : (Long) channelWidthMhz));
+      Object primaryPhy = list.get(8);
+      pigeonResult.setPrimaryPhy(primaryPhy == null ? null : BluetoothPhy.values()[(int) primaryPhy]);
+      Object secondaryPhy = list.get(9);
+      pigeonResult.setSecondaryPhy(secondaryPhy == null ? null : BluetoothPhy.values()[(int) secondaryPhy]);
+      return pigeonResult;
+    }
+  }
+
   /**
    * Payload send from native to dart contains raw data and metadata
    *
@@ -146,50 +401,17 @@ public class Pigeon {
       this.receivedTimestamp = setterArg;
     }
 
-    private @NonNull String macAddress;
+    private @NonNull ODIDMetadata metadata;
 
-    public @NonNull String getMacAddress() {
-      return macAddress;
+    public @NonNull ODIDMetadata getMetadata() {
+      return metadata;
     }
 
-    public void setMacAddress(@NonNull String setterArg) {
+    public void setMetadata(@NonNull ODIDMetadata setterArg) {
       if (setterArg == null) {
-        throw new IllegalStateException("Nonnull field \"macAddress\" is null.");
+        throw new IllegalStateException("Nonnull field \"metadata\" is null.");
       }
-      this.macAddress = setterArg;
-    }
-
-    private @Nullable Long rssi;
-
-    public @Nullable Long getRssi() {
-      return rssi;
-    }
-
-    public void setRssi(@Nullable Long setterArg) {
-      this.rssi = setterArg;
-    }
-
-    private @NonNull MessageSource source;
-
-    public @NonNull MessageSource getSource() {
-      return source;
-    }
-
-    public void setSource(@NonNull MessageSource setterArg) {
-      if (setterArg == null) {
-        throw new IllegalStateException("Nonnull field \"source\" is null.");
-      }
-      this.source = setterArg;
-    }
-
-    private @Nullable String btName;
-
-    public @Nullable String getBtName() {
-      return btName;
-    }
-
-    public void setBtName(@Nullable String setterArg) {
-      this.btName = setterArg;
+      this.metadata = setterArg;
     }
 
     /** Constructor is non-public to enforce null safety; use Builder. */
@@ -211,31 +433,10 @@ public class Pigeon {
         return this;
       }
 
-      private @Nullable String macAddress;
+      private @Nullable ODIDMetadata metadata;
 
-      public @NonNull Builder setMacAddress(@NonNull String setterArg) {
-        this.macAddress = setterArg;
-        return this;
-      }
-
-      private @Nullable Long rssi;
-
-      public @NonNull Builder setRssi(@Nullable Long setterArg) {
-        this.rssi = setterArg;
-        return this;
-      }
-
-      private @Nullable MessageSource source;
-
-      public @NonNull Builder setSource(@NonNull MessageSource setterArg) {
-        this.source = setterArg;
-        return this;
-      }
-
-      private @Nullable String btName;
-
-      public @NonNull Builder setBtName(@Nullable String setterArg) {
-        this.btName = setterArg;
+      public @NonNull Builder setMetadata(@NonNull ODIDMetadata setterArg) {
+        this.metadata = setterArg;
         return this;
       }
 
@@ -243,23 +444,17 @@ public class Pigeon {
         ODIDPayload pigeonReturn = new ODIDPayload();
         pigeonReturn.setRawData(rawData);
         pigeonReturn.setReceivedTimestamp(receivedTimestamp);
-        pigeonReturn.setMacAddress(macAddress);
-        pigeonReturn.setRssi(rssi);
-        pigeonReturn.setSource(source);
-        pigeonReturn.setBtName(btName);
+        pigeonReturn.setMetadata(metadata);
         return pigeonReturn;
       }
     }
 
     @NonNull
     ArrayList<Object> toList() {
-      ArrayList<Object> toListResult = new ArrayList<Object>(6);
+      ArrayList<Object> toListResult = new ArrayList<Object>(3);
       toListResult.add(rawData);
       toListResult.add(receivedTimestamp);
-      toListResult.add(macAddress);
-      toListResult.add(rssi);
-      toListResult.add(source == null ? null : source.index);
-      toListResult.add(btName);
+      toListResult.add((metadata == null) ? null : metadata.toList());
       return toListResult;
     }
 
@@ -269,14 +464,8 @@ public class Pigeon {
       pigeonResult.setRawData((byte[]) rawData);
       Object receivedTimestamp = list.get(1);
       pigeonResult.setReceivedTimestamp((receivedTimestamp == null) ? null : ((receivedTimestamp instanceof Integer) ? (Integer) receivedTimestamp : (Long) receivedTimestamp));
-      Object macAddress = list.get(2);
-      pigeonResult.setMacAddress((String) macAddress);
-      Object rssi = list.get(3);
-      pigeonResult.setRssi((rssi == null) ? null : ((rssi instanceof Integer) ? (Integer) rssi : (Long) rssi));
-      Object source = list.get(4);
-      pigeonResult.setSource(source == null ? null : MessageSource.values()[(int) source]);
-      Object btName = list.get(5);
-      pigeonResult.setBtName((String) btName);
+      Object metadata = list.get(2);
+      pigeonResult.setMetadata((metadata == null) ? null : ODIDMetadata.fromList((ArrayList<Object>) metadata));
       return pigeonResult;
     }
   }
@@ -658,6 +847,8 @@ public class Pigeon {
     protected Object readValueOfType(byte type, @NonNull ByteBuffer buffer) {
       switch (type) {
         case (byte) 128:
+          return ODIDMetadata.fromList((ArrayList<Object>) readValue(buffer));
+        case (byte) 129:
           return ODIDPayload.fromList((ArrayList<Object>) readValue(buffer));
         default:
           return super.readValueOfType(type, buffer);
@@ -666,8 +857,11 @@ public class Pigeon {
 
     @Override
     protected void writeValue(@NonNull ByteArrayOutputStream stream, Object value) {
-      if (value instanceof ODIDPayload) {
+      if (value instanceof ODIDMetadata) {
         stream.write(128);
+        writeValue(stream, ((ODIDMetadata) value).toList());
+      } else if (value instanceof ODIDPayload) {
+        stream.write(129);
         writeValue(stream, ((ODIDPayload) value).toList());
       } else {
         super.writeValue(stream, value);
@@ -679,7 +873,7 @@ public class Pigeon {
   public interface PayloadApi {
 
     @NonNull 
-    ODIDPayload buildPayload(@NonNull byte[] rawData, @NonNull MessageSource source, @NonNull String macAddress, @Nullable String btName, @NonNull Long rssi, @NonNull Long receivedTimestamp);
+    ODIDPayload buildPayload(@NonNull byte[] rawData, @NonNull Long receivedTimestamp, @NonNull ODIDMetadata metadata);
 
     /** The codec used by PayloadApi. */
     static @NonNull MessageCodec<Object> getCodec() {
@@ -697,13 +891,10 @@ public class Pigeon {
                 ArrayList<Object> wrapped = new ArrayList<Object>();
                 ArrayList<Object> args = (ArrayList<Object>) message;
                 byte[] rawDataArg = (byte[]) args.get(0);
-                MessageSource sourceArg = args.get(1) == null ? null : MessageSource.values()[(int) args.get(1)];
-                String macAddressArg = (String) args.get(2);
-                String btNameArg = (String) args.get(3);
-                Number rssiArg = (Number) args.get(4);
-                Number receivedTimestampArg = (Number) args.get(5);
+                Number receivedTimestampArg = (Number) args.get(1);
+                ODIDMetadata metadataArg = (ODIDMetadata) args.get(2);
                 try {
-                  ODIDPayload output = api.buildPayload(rawDataArg, sourceArg, macAddressArg, btNameArg, (rssiArg == null) ? null : rssiArg.longValue(), (receivedTimestampArg == null) ? null : receivedTimestampArg.longValue());
+                  ODIDPayload output = api.buildPayload(rawDataArg, (receivedTimestampArg == null) ? null : receivedTimestampArg.longValue(), metadataArg);
                   wrapped.add(0, output);
                 }
  catch (Throwable exception) {

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -52,15 +52,23 @@ class BluetoothScanner(
                 if (result.getPrimaryPhy() == BluetoothDevice.PHY_LE_CODED)
                     source = Pigeon.MessageSource.BLUETOOTH_LONG_RANGE;
             }
+
             // if using BLE, max size of data is MAX_BLE_ADV_SIZE
             // if using BT5, data can be longer up to 256 bytes
             val isBLE = maxAdvDataLen() <= MAX_BLE_ADV_SIZE
+
+            val metadataBuilder = Pigeon.ODIDMetadata.Builder().apply {
+                setMacAddress(result.device.address)
+                setSource(source)
+                setRssi(result.rssi.toLong())
+                setBtName(result.device.name)
+                setPrimaryPhy(phyFromInt(result.getPrimaryPhy()))
+                setSecondaryPhy(phyFromInt(result.getSecondaryPhy()))
+            }
+
             receiveData(
                 if(isBLE) getDataFromIndex(bytes, BT_OFFSET, MAX_BLE_ADV_SIZE) else offsetData(bytes, BT_OFFSET),
-                result.device.address,
-                source,
-                result.rssi.toLong(),
-                result.device.name,
+                metadataBuilder.build(),
             )
         }
 
@@ -168,4 +176,7 @@ class BluetoothScanner(
         }
         return scanSettings
     }
+
+    fun phyFromInt(value: Int): Pigeon.BluetoothPhy? =
+    Pigeon.BluetoothPhy.values().firstOrNull { it.index == value }
 }

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/ODIDScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/ODIDScanner.kt
@@ -34,25 +34,22 @@ abstract class ODIDScanner(
 
     abstract fun onAdapterStateReceived()
 
-    override fun buildPayload(rawData: ByteArray, source: Pigeon.MessageSource, macAddress: String, btName: String?, rssi: Long, receivedTimestamp: Long): Pigeon.ODIDPayload {
-        val builder = Pigeon.ODIDPayload.Builder()
-
-        builder.setRawData(rawData)
-        builder.setReceivedTimestamp(receivedTimestamp)
-        builder.setMacAddress(macAddress)
-        builder.setSource(source)
-        builder.setRssi(rssi)
-        builder.setBtName(btName)
+    override fun buildPayload(rawData: ByteArray, receivedTimestamp: Long, metadata: Pigeon.ODIDMetadata): Pigeon.ODIDPayload {
+        val builder = Pigeon.ODIDPayload.Builder().apply {
+            setRawData(rawData)
+            setReceivedTimestamp(receivedTimestamp)
+            setMetadata(metadata)
+        }
 
         return builder.build()
     }
     
     /// receive data and metadata, create [ODIDPayload] and sent to stream
     fun receiveData(
-        data: ByteArray, macAddress: String, source: Pigeon.MessageSource, rssi: Long = 0, btName: String? = null,
+        data: ByteArray, metadata: Pigeon.ODIDMetadata,
     ) {
         val payload = buildPayload(
-            data, source, macAddress, btName, rssi, System.currentTimeMillis()
+            data, System.currentTimeMillis(), metadata,
         )
 
         odidPayloadStreamHandler.send(payload.toList() as Any)        

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiNaNScanner.kt
@@ -58,12 +58,16 @@ class WifiNaNScanner (
                     serviceSpecificInfo: ByteArray?,
                     matchFilter: MutableList<ByteArray>?
                 ) {
-                    if (serviceSpecificInfo != null)
+                    if (serviceSpecificInfo != null) {
+                        val metadataBuilder = Pigeon.ODIDMetadata.Builder().apply {
+                            setMacAddress(peerHandle.hashCode().toString())
+                            setSource(Pigeon.MessageSource.WIFI_NAN)
+                        }
                         receiveData(
                             offsetData(serviceSpecificInfo, WIFI_NAN_OFFSET),
-                            peerHandle.hashCode().toString(),
-                            Pigeon.MessageSource.WIFI_NAN,
+                            metadataBuilder.build()
                         )
+                    }
                 }
             }, null)
         }

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
@@ -143,11 +143,28 @@ class WifiScanner (
 
     private fun receiveBeaconData(scanResult: ScanResult, bytes: ByteArray) { 
         if(checkDRICID(bytes)){
+            val channelWidth = when(scanResult.channelWidth) {
+                ScanResult.CHANNEL_WIDTH_20MHZ -> 20
+                ScanResult.CHANNEL_WIDTH_40MHZ -> 40
+                ScanResult.CHANNEL_WIDTH_80MHZ -> 80
+                ScanResult.CHANNEL_WIDTH_160MHZ -> 160
+                ScanResult.CHANNEL_WIDTH_320MHZ -> 320
+                else -> null
+            }
+
+            val metadataBuilder = Pigeon.ODIDMetadata.Builder().apply {
+                setMacAddress(scanResult.BSSID)
+                setSource(Pigeon.MessageSource.WIFI_BEACON)
+                setRssi(scanResult.level.toLong())
+                setFrequency(scanResult.frequency.toLong())
+                setCenterFreq0(scanResult.centerFreq0.toLong())
+                setCenterFreq1(scanResult.centerFreq1.toLong())
+                setChannelWidthMhz(channelWidth?.toLong())
+            }
+
             receiveData(
                 offsetData(bytes, WIFI_BEACON_OFFSET),
-                scanResult.BSSID, 
-                Pigeon.MessageSource.WIFI_BEACON,
-                scanResult.level.toLong(),
+                metadataBuilder.build()
             )
         }
     }

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -95,8 +95,8 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
         )    
     }
     
-    func buildPayloadRawData(_ rawData: FlutterStandardTypedData, source: DTGMessageSource, macAddress: String, btName: String?, rssi: NSNumber, receivedTimestamp: NSNumber, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> DTGODIDPayload? {
-        return DTGODIDPayload.make(withRawData: rawData, receivedTimestamp: receivedTimestamp, macAddress: macAddress, rssi: rssi, source: source, btName: btName)
+    func buildPayloadRawData(_ rawData: FlutterStandardTypedData, receivedTimestamp receivedTimestamp: NSNumber, metadata: DTGODIDMetadata, error: AutoreleasingUnsafeMutablePointer<FlutterError?>) -> DTGODIDPayload? {
+        return DTGODIDPayload.make(withRawData: rawData, receivedTimestamp: receivedTimestamp ,metadata: metadata)
     }
 
     private func handleOdidMessage(advertisementData: [String : Any], didDiscover peripheral: CBPeripheral, rssi RSSI: NSNumber, offset: NSNumber){
@@ -106,7 +106,8 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
         }
         var err: FlutterError?
         let systimestamp = Int(Date().timeIntervalSince1970 * 1000)
-        let payload = buildPayloadRawData(data, source: DTGMessageSource.bluetoothLegacy, macAddress: peripheral.identifier.uuidString, btName: peripheral.name, rssi: RSSI.intValue as NSNumber, receivedTimestamp: systimestamp as NSNumber, error: &err)
+        let metadata = DTGODIDMetadata.make(withMacAddress: peripheral.identifier.uuidString, source: DTGMessageSource.bluetoothLegacy, rssi: RSSI.intValue as NSNumber, btName:  peripheral.name, frequency: nil, centerFreq0: nil, centerFreq1: nil, channelWidthMhz: nil, primaryPhy: DTGBluetoothPhy.unknown, secondaryPhy: DTGBluetoothPhy.unknown)
+        let payload = buildPayloadRawData(data, receivedTimestamp: systimestamp as NSNumber , metadata: metadata , error: &err)
 
         odidPayloadStreamHandler.send(payload!.toList() as Any)
     }

--- a/ios/Classes/pigeon.h
+++ b/ios/Classes/pigeon.h
@@ -43,7 +43,41 @@ typedef NS_ENUM(NSUInteger, DTGWifiState) {
   DTGWifiStateEnabled = 3,
 };
 
+typedef NS_ENUM(NSUInteger, DTGBluetoothPhy) {
+  DTGBluetoothPhyNone = 0,
+  DTGBluetoothPhyPhy1M = 1,
+  DTGBluetoothPhyPhy2M = 2,
+  DTGBluetoothPhyPhyLECoded = 3,
+  DTGBluetoothPhyUnknown = 4,
+};
+
+@class DTGODIDMetadata;
 @class DTGODIDPayload;
+
+@interface DTGODIDMetadata : NSObject
+/// `init` unavailable to enforce nonnull fields, see the `make` class method.
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)makeWithMacAddress:(NSString *)macAddress
+    source:(DTGMessageSource)source
+    rssi:(nullable NSNumber *)rssi
+    btName:(nullable NSString *)btName
+    frequency:(nullable NSNumber *)frequency
+    centerFreq0:(nullable NSNumber *)centerFreq0
+    centerFreq1:(nullable NSNumber *)centerFreq1
+    channelWidthMhz:(nullable NSNumber *)channelWidthMhz
+    primaryPhy:(DTGBluetoothPhy)primaryPhy
+    secondaryPhy:(DTGBluetoothPhy)secondaryPhy;
+@property(nonatomic, copy) NSString * macAddress;
+@property(nonatomic, assign) DTGMessageSource source;
+@property(nonatomic, strong, nullable) NSNumber * rssi;
+@property(nonatomic, copy, nullable) NSString * btName;
+@property(nonatomic, strong, nullable) NSNumber * frequency;
+@property(nonatomic, strong, nullable) NSNumber * centerFreq0;
+@property(nonatomic, strong, nullable) NSNumber * centerFreq1;
+@property(nonatomic, strong, nullable) NSNumber * channelWidthMhz;
+@property(nonatomic, assign) DTGBluetoothPhy primaryPhy;
+@property(nonatomic, assign) DTGBluetoothPhy secondaryPhy;
+@end
 
 /// Payload send from native to dart contains raw data and metadata
 @interface DTGODIDPayload : NSObject
@@ -52,16 +86,10 @@ typedef NS_ENUM(NSUInteger, DTGWifiState) {
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)makeWithRawData:(FlutterStandardTypedData *)rawData
     receivedTimestamp:(NSNumber *)receivedTimestamp
-    macAddress:(NSString *)macAddress
-    rssi:(nullable NSNumber *)rssi
-    source:(DTGMessageSource)source
-    btName:(nullable NSString *)btName;
+    metadata:(DTGODIDMetadata *)metadata;
 @property(nonatomic, strong) FlutterStandardTypedData * rawData;
 @property(nonatomic, strong) NSNumber * receivedTimestamp;
-@property(nonatomic, copy) NSString * macAddress;
-@property(nonatomic, strong, nullable) NSNumber * rssi;
-@property(nonatomic, assign) DTGMessageSource source;
-@property(nonatomic, copy, nullable) NSString * btName;
+@property(nonatomic, strong) DTGODIDMetadata * metadata;
 @end
 
 /// The codec used by DTGApi.
@@ -89,7 +117,7 @@ NSObject<FlutterMessageCodec> *DTGPayloadApiGetCodec(void);
 
 @protocol DTGPayloadApi
 /// @return `nil` only when `error != nil`.
-- (nullable DTGODIDPayload *)buildPayloadRawData:(FlutterStandardTypedData *)rawData source:(DTGMessageSource)source macAddress:(NSString *)macAddress btName:(nullable NSString *)btName rssi:(NSNumber *)rssi receivedTimestamp:(NSNumber *)receivedTimestamp error:(FlutterError *_Nullable *_Nonnull)error;
+- (nullable DTGODIDPayload *)buildPayloadRawData:(FlutterStandardTypedData *)rawData receivedTimestamp:(NSNumber *)receivedTimestamp metadata:(DTGODIDMetadata *)metadata error:(FlutterError *_Nullable *_Nonnull)error;
 @end
 
 extern void DTGPayloadApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<DTGPayloadApi> *_Nullable api);

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -124,8 +124,7 @@ class FlutterOpenDroneId {
       pigeon.ODIDPayload payload, DriSourceType sourceType) {
     final storedPack = _storedPacks[payload.metadata.macAddress] ??
         MessageContainer(
-          macAddress: payload.metadata.macAddress,
-          source: payload.metadata.source,
+          metadata: payload.metadata,
           lastUpdate:
               DateTime.fromMillisecondsSinceEpoch(payload.receivedTimestamp),
         );
@@ -148,8 +147,7 @@ class FlutterOpenDroneId {
     final updatedPack = storedPack.update(
       message: message,
       receivedTimestamp: payload.receivedTimestamp,
-      rssi: payload.metadata.rssi,
-      source: payload.metadata.source,
+      metadata: payload.metadata,
     );
     // update was refused if updatedPack is null
     if (updatedPack != null) {

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -122,10 +122,10 @@ class FlutterOpenDroneId {
 
   static void _updatePacks(
       pigeon.ODIDPayload payload, DriSourceType sourceType) {
-    final storedPack = _storedPacks[payload.macAddress] ??
+    final storedPack = _storedPacks[payload.metadata.macAddress] ??
         MessageContainer(
-          macAddress: payload.macAddress,
-          source: payload.source,
+          macAddress: payload.metadata.macAddress,
+          source: payload.metadata.source,
           lastUpdate:
               DateTime.fromMillisecondsSinceEpoch(payload.receivedTimestamp),
         );
@@ -135,11 +135,11 @@ class FlutterOpenDroneId {
     } catch (e) {
       throw ODIDMessageParsingException(
         relatedException: e,
-        macAddress: payload.macAddress,
-        rssi: payload.rssi,
+        macAddress: payload.metadata.macAddress,
+        rssi: payload.metadata.rssi,
         receivedTimestamp: payload.receivedTimestamp,
-        source: payload.source,
-        btName: payload.btName,
+        source: payload.metadata.source,
+        btName: payload.metadata.btName,
       );
     }
 
@@ -148,12 +148,12 @@ class FlutterOpenDroneId {
     final updatedPack = storedPack.update(
       message: message,
       receivedTimestamp: payload.receivedTimestamp,
-      rssi: payload.rssi,
-      source: payload.source,
+      rssi: payload.metadata.rssi,
+      source: payload.metadata.source,
     );
     // update was refused if updatedPack is null
     if (updatedPack != null) {
-      _storedPacks[payload.macAddress] = updatedPack;
+      _storedPacks[payload.metadata.macAddress] = updatedPack;
       return switch (sourceType) {
         DriSourceType.Bluetooth =>
           _bluetoothMessagesController.add(updatedPack),

--- a/pigeon/schema.dart
+++ b/pigeon/schema.dart
@@ -33,27 +33,61 @@ enum WifiState {
   Enabled,
 }
 
+enum BluetoothPhy {
+  None,
+  Phy1M,
+  Phy2M,
+  PhyLECoded,
+  Unknown,
+}
+
+class ODIDMetadata {
+  final String macAddress;
+
+  final MessageSource source;
+
+  final int? rssi;
+
+  final String? btName;
+
+  final int? frequency;
+
+  final int? centerFreq0;
+
+  final int? centerFreq1;
+
+  final int? channelWidthMhz;
+
+  final BluetoothPhy? primaryPhy;
+
+  final BluetoothPhy? secondaryPhy;
+
+  ODIDMetadata({
+    required this.macAddress,
+    required this.source,
+    this.rssi,
+    this.btName,
+    this.frequency,
+    this.channelWidthMhz,
+    this.centerFreq0,
+    this.centerFreq1,
+    this.primaryPhy,
+    this.secondaryPhy,
+  });
+}
+
 /// Payload send from native to dart contains raw data and metadata
 class ODIDPayload {
   final Uint8List rawData;
 
   final int receivedTimestamp;
 
-  final String macAddress;
-
-  final int? rssi;
-
-  final MessageSource source;
-
-  final String? btName;
+  final ODIDMetadata metadata;
 
   ODIDPayload(
     this.rawData,
     this.receivedTimestamp,
-    this.macAddress,
-    this.rssi,
-    this.source,
-    this.btName,
+    this.metadata,
   );
 }
 
@@ -88,6 +122,6 @@ abstract class Api {
 // ODIDPayload is not generated until used in API
 @HostApi()
 abstract class PayloadApi {
-  ODIDPayload buildPayload(Uint8List rawData, MessageSource source,
-      String macAddress, String? btName, int rssi, int receivedTimestamp);
+  ODIDPayload buildPayload(
+      Uint8List rawData, int receivedTimestamp, ODIDMetadata metadata);
 }


### PR DESCRIPTION
Add ODIDMetadata class to pigeon schema. ODIDMetadata contains metadata that were previously saved in MessageContainer plus new transmission information used in data collection: bluetooth phy, frequencies etc.