### PR TITLE
Fix: android crashes

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -94,13 +94,14 @@ class BluetoothScanner(
     override fun cancel() {
         isScanning = false
         bluetoothStateHandler.send(false)
+        if (!bluetoothAdapter.isEnabled) return
         bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onAdapterStateReceived() {
         val rawState = bluetoothAdapter.state
-        if (rawState == BluetoothAdapter.STATE_OFF || rawState == BluetoothAdapter.STATE_TURNING_OFF) {
+        if ((rawState == BluetoothAdapter.STATE_OFF || rawState == BluetoothAdapter.STATE_TURNING_OFF) && isScanning) {
             cancel()
         }
     }

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/WifiScanner.kt
@@ -95,7 +95,7 @@ class WifiScanner (
         if(wifiManager.isScanAlwaysAvailable())
             return
         val rawState = wifiManager.getWifiState()
-        if (rawState == WifiManager.WIFI_STATE_DISABLED || rawState == WifiManager.WIFI_STATE_DISABLING) {
+        if ((rawState == WifiManager.WIFI_STATE_DISABLED || rawState == WifiManager.WIFI_STATE_DISABLING) && isScanning) {
             cancel()
         }
     }


### PR DESCRIPTION
I found 2 crashes Dronetag App in Google Play console. Both are related to handling adapter state, more specifically, turning off scans when adapters are turned off.

In the latest released version 2.136.0. there was just this [exception](https://play.google.com/console/u/0/developers/6935129863038122535/app/4975063036752240987/vitals/crashes/c890f0ff3a150e718146215a5dcad35b/details?days=28&versionCode=1051&isUserPerceived=true), exception from `BluetoothScanner.kt`.
In `cancel()` method, accessing `bluetoothAdapter.bluetoothLeScanner` when bluetooth adapter is turned off resulted in a crash. I added check:  `if (!bluetoothAdapter.isEnabled) return`

Second [exception](https://play.google.com/console/u/0/developers/6935129863038122535/app/4975063036752240987/vitals/crashes/96beed169647d17845b616e5932ecf82/details?days=28&versionCode=1051&isUserPerceived=true) is from `WifiScanner.kt`. Again problem is in `cancel` method, there is `context.unregisterReceiver(adapterStateReceiver)` call, which results in exception when receiver was not registered before. I fixed this by only calling cancel if scans were started before (`isScanning` is true).

These issues do not appear all the time on all phones. I was able to reproduce the issue with bluetooth scanner on Huawei we have in the office, you can build the Dronetag app with this version of flutter-odid and try on the Huawei phone.
