### PR TITLE
feat: add initialize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ samples, guidance on mobile development, and a full API reference.
 1. Install the project using `flutter pub get`
 2. Generate Pigeon classes by running shell script in `scripts/pigeon_generate.sh`
 
-## Setting up permissions
+## Usage & Setting up permissions
 
-Enabling scanning the surroundings for Wi-Fi and Bluetooth Remote ID advertisements requires setting up permissions. App has to request required permissions, the plugin only checks that permissions are granted. If some permissions are missing, the plugin throws `PermissionsMissingException` when attempting to start the scan. Use for example the [permission handler package](https://pub.dev/packages/permission_handler) to request permissions.
+Plugin needs to be initialized before first use by calling `FlutterOpenDroneId.initialize()`. Moreover, enabling scanning the surroundings for Wi-Fi and Bluetooth Remote ID advertisements requires setting up permissions. App has to request required permissions, the plugin only checks that permissions are granted. If some permissions are missing, the plugin throws `PermissionsMissingException` when attempting to start the scan. Use for example the [permission handler package](https://pub.dev/packages/permission_handler) to request permissions.
 
 
 ### Android Setup

--- a/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
+++ b/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
@@ -290,6 +290,10 @@ public class Pigeon {
   /** Generated interface from Pigeon that represents a handler of messages from Flutter. */
   public interface Api {
 
+    void initialize(@NonNull Result<Void> result);
+
+    void isInitialized(@NonNull Result<Boolean> result);
+
     void startScanBluetooth(@NonNull Result<Void> result);
 
     void startScanWifi(@NonNull Result<Void> result);
@@ -320,6 +324,60 @@ public class Pigeon {
     }
     /**Sets up an instance of `Api` to handle messages through the `binaryMessenger`. */
     static void setup(@NonNull BinaryMessenger binaryMessenger, @Nullable Api api) {
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.flutter_opendroneid.Api.initialize", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                Result<Void> resultCallback =
+                    new Result<Void>() {
+                      public void success(Void result) {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.initialize(resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.flutter_opendroneid.Api.isInitialized", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                Result<Boolean> resultCallback =
+                    new Result<Boolean>() {
+                      public void success(Boolean result) {
+                        wrapped.add(0, result);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.isInitialized(resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
       {
         BasicMessageChannel<Object> channel =
             new BasicMessageChannel<>(

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/Exceptions.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/Exceptions.kt
@@ -1,0 +1,5 @@
+package cz.dronetag.flutter_opendroneid
+
+class PluginNotInitializedException : Exception("Plugin was not initialized. Call the initialize method before first use") {}
+
+class PluginNotAttachedException : Exception("Unable to initialize, plugin was not attached to activity") {}

--- a/ios/Classes/PluginNotInitializedException.swift
+++ b/ios/Classes/PluginNotInitializedException.swift
@@ -1,0 +1,7 @@
+import Flutter
+
+public class PluginNotInitializedException : FlutterError {
+    override convenience init() {
+        self.init(code: "uninitialized", message: "Plugin was not initialized", details: "Call the initialize method before using the plugin")
+    }
+}

--- a/ios/Classes/pigeon.h
+++ b/ios/Classes/pigeon.h
@@ -68,6 +68,8 @@ typedef NS_ENUM(NSUInteger, DTGWifiState) {
 NSObject<FlutterMessageCodec> *DTGApiGetCodec(void);
 
 @protocol DTGApi
+- (void)initializeWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+- (void)isInitializedWithCompletion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)startScanBluetoothWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)startScanWifiWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopScanBluetoothWithCompletion:(void (^)(FlutterError *_Nullable))completion;

--- a/ios/Classes/pigeon.m
+++ b/ios/Classes/pigeon.m
@@ -86,6 +86,40 @@ void DTGApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<DTGApi> *a
   {
     FlutterBasicMessageChannel *channel =
       [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.flutter_opendroneid.Api.initialize"
+        binaryMessenger:binaryMessenger
+        codec:DTGApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(initializeWithCompletion:)], @"DTGApi api (%@) doesn't respond to @selector(initializeWithCompletion:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api initializeWithCompletion:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.flutter_opendroneid.Api.isInitialized"
+        binaryMessenger:binaryMessenger
+        codec:DTGApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(isInitializedWithCompletion:)], @"DTGApi api (%@) doesn't respond to @selector(isInitializedWithCompletion:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        [api isInitializedWithCompletion:^(NSNumber *_Nullable output, FlutterError *_Nullable error) {
+          callback(wrapResult(output, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
         initWithName:@"dev.flutter.pigeon.flutter_opendroneid.Api.startScanBluetooth"
         binaryMessenger:binaryMessenger
         codec:DTGApiGetCodec()];

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -51,6 +51,16 @@ class FlutterOpenDroneId {
       await _api.wifiState() ==
       pigeon.WifiState.values.indexOf(pigeon.WifiState.Enabled);
 
+  /// Initialize the plugin before using.
+  static Future<void> initialize() async {
+    await _api.initialize();
+  }
+
+  /// Check whether plugin was correctly initialized.
+  static Future<bool> isInitialized() async {
+    return await _api.isInitialized();
+  }
+
   /// Starts scanning for nearby traffic
   /// For Bluetooth scanning, bluetooth perm. are required on both platforms,
   /// Android requires Bluetooth scan permission location permission on ver.< 12
@@ -61,6 +71,8 @@ class FlutterOpenDroneId {
   ///
   /// To further receive data, listen to [receivedMessages]
   /// stream.
+  ///
+  /// Plugin must be initialized by calling [initialize] before using.
   static Future<void> startScan(DriSourceType sourceType) async {
     if (sourceType == DriSourceType.Bluetooth) {
       await _assertBluetoothPermissions();

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -98,6 +98,55 @@ class Api {
 
   static const MessageCodec<Object?> codec = StandardMessageCodec();
 
+  Future<void> initialize() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.flutter_opendroneid.Api.initialize', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<bool> isInitialized() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.flutter_opendroneid.Api.isInitialized', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
+
   Future<void> startScanBluetooth() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.flutter_opendroneid.Api.startScanBluetooth', codec,

--- a/pigeon/schema.dart
+++ b/pigeon/schema.dart
@@ -60,6 +60,10 @@ class ODIDPayload {
 @HostApi()
 abstract class Api {
   @async
+  void initialize();
+  @async
+  bool isInitialized();
+  @async
   void startScanBluetooth();
   @async
   void startScanWifi();


### PR DESCRIPTION
Add `initialize()` and `bool isInitialized` to platform API. implement initialization on both iOS and Android. This prevents permission requests immediately on app start on iOS.

#### iOS:
in `SwiftFlutterOpendroneidPlugin`, bluetooth scanner is now nullable. Instantiate scanner in initialize method. Plugin is initialized when scanner is not null. Calling methods that use bluetooth scanner before initialization throws `PluginNotInitializedException` with ` "Plugin was not initialized"` message.

#### Android:
Similar change as on iOS, create all scanners in initialize method. `Activity` and `Context` which are provided in `onAttachedToActivity` are required when creating scanners, so I saved them to `FlutterOpendroneidPlugin`. `PluginNotInitializedException` is thrown when using API before init. `PluginNotAttachedException` is thrown when `context` or `boundActivity` are null when initializing.