### PR TITLE
Added support for different Bluetooth RID service UUID

### DIFF
--- a/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
+++ b/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
@@ -294,7 +294,7 @@ public class Pigeon {
 
     void isInitialized(@NonNull Result<Boolean> result);
 
-    void startScanBluetooth(@NonNull Result<Void> result);
+    void startScanBluetooth(@Nullable String serviceUuid, @NonNull Result<Void> result);
 
     void startScanWifi(@NonNull Result<Void> result);
 
@@ -386,6 +386,8 @@ public class Pigeon {
           channel.setMessageHandler(
               (message, reply) -> {
                 ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String serviceUuidArg = (String) args.get(0);
                 Result<Void> resultCallback =
                     new Result<Void>() {
                       public void success(Void result) {
@@ -399,7 +401,7 @@ public class Pigeon {
                       }
                     };
 
-                api.startScanBluetooth(resultCallback);
+                api.startScanBluetooth(serviceUuidArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
+++ b/android/src/main/java/cz/dronetag/flutter_opendroneid/Pigeon.java
@@ -304,6 +304,8 @@ public class Pigeon {
 
     void setBtScanPriority(@NonNull ScanPriority priority, @NonNull Result<Void> result);
 
+    void setBtServiceUuid(@Nullable String serviceUuid, @NonNull Result<Void> result);
+
     void isScanningBluetooth(@NonNull Result<Boolean> result);
 
     void isScanningWifi(@NonNull Result<Boolean> result);
@@ -512,6 +514,35 @@ public class Pigeon {
                     };
 
                 api.setBtScanPriority(priorityArg, resultCallback);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger, "dev.flutter.pigeon.flutter_opendroneid.Api.setBtServiceUuid", getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                ArrayList<Object> wrapped = new ArrayList<Object>();
+                ArrayList<Object> args = (ArrayList<Object>) message;
+                String serviceUuidArg = (String) args.get(0);
+                Result<Void> resultCallback =
+                    new Result<Void>() {
+                      public void success(Void result) {
+                        wrapped.add(0, null);
+                        reply.reply(wrapped);
+                      }
+
+                      public void error(Throwable error) {
+                        ArrayList<Object> wrappedError = wrapError(error);
+                        reply.reply(wrappedError);
+                      }
+                    };
+
+                api.setBtServiceUuid(serviceUuidArg, resultCallback);
               });
         } else {
           channel.setMessageHandler(null);

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
@@ -127,9 +127,11 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun startScanBluetooth(result: Pigeon.Result<Void>) {
+    override fun startScanBluetooth(serviceUuid: String?, result: Pigeon.Result<Void>) {
         bluetoothScanner?.let {
+            it.setServiceUuid(serviceUuid)
             it.scan()
+
             return result.success(null)
         }
         return result.error(PluginNotInitializedException())

--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/FlutterOpendroneidPlugin.kt
@@ -172,6 +172,14 @@ class FlutterOpendroneidPlugin : FlutterPlugin, ActivityAware, Pigeon.Api {
         return result.error(PluginNotInitializedException())
     }
 
+    override fun setBtServiceUuid(serviceUuid: String?, result: Pigeon.Result<Void>) {
+        bluetoothScanner?.let {
+            it.setServiceUuid(serviceUuid)
+            return result.success(null)
+        }
+        return result.error(PluginNotInitializedException())
+    }
+
     override fun isScanningBluetooth(result: Pigeon.Result<Boolean>){
         bluetoothScanner?.let {
             return result.success(it.isScanning)

--- a/ios/Classes/Scanner/BluetoothScanner.swift
+++ b/ios/Classes/Scanner/BluetoothScanner.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreBluetooth
 
 class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
+    static let defaultShortServiceUuid = "fffa"
+
     private let odidPayloadStreamHandler: StreamHandler
     private let scanStateHandler: StreamHandler
     
@@ -9,9 +11,15 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
     private var scanPriority: DTGScanPriority = .high
     private var restartTimer: Timer?;
     private let restartIntervalSec: TimeInterval = 120.0
+    private var shortServiceUuid: String? = nil
     let dispatchQueue: DispatchQueue = DispatchQueue(label: "BluetoothScanner")
     
-    static let serviceUUID = CBUUID(string: "0000fffa-0000-1000-8000-00805f9b34fb")
+    private var serviceUUID: CBUUID {
+        get {
+            let shortUuid = shortServiceUuid ?? BluetoothScanner.defaultShortServiceUuid
+            return CBUUID(string: "0000\(shortUuid.lowercased())-0000-1000-8000-00805f9b34fb")
+        }
+    }
     static let odidAdCode: [UInt8] = [ 0x0D ]
     
     init(odidPayloadStreamHandler: StreamHandler, scanStateHandler: StreamHandler) {
@@ -57,17 +65,17 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
     func setScanPriority(priority: DTGScanPriority)
     {
         scanPriority = priority
-        // if scan is running when settting high prio, call scan to restart and set timer
-        // if scan is running when setting low prio, just cancel restart timer
-        if centralManager.isScanning {
-            if scanPriority == .low {
-                restartTimer?.invalidate()
-            }
-            else {
-                centralManager.stopScan()
-                scan()
-            }
+        restartScan()
+    }
+
+    func setServiceUuid(value: String?) {
+        if value != nil && (value!.count != 4 || !value!.isHexNumber) {
+            // TODO return error on invalid service UUID
+            return
         }
+
+        shortServiceUuid = value
+        restartScan()
     }
 
     func updateScanState() {
@@ -88,7 +96,7 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
 
     private func scanForPeripherals(){
         centralManager.scanForPeripherals(
-            withServices: [BluetoothScanner.serviceUUID],
+            withServices: [serviceUUID],
             options: [
                 CBCentralManagerScanOptionAllowDuplicatesKey: true,
             ]
@@ -120,11 +128,11 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
         let serviceDataDict = serviceData as! Dictionary<CBUUID, Any>
         
         // Find the ODID service UUID
-        guard serviceDataDict.keys.contains(BluetoothScanner.serviceUUID) else {
+        guard serviceDataDict.keys.contains(serviceUUID) else {
             return nil
         }
         
-        let data = serviceDataDict[BluetoothScanner.serviceUUID] as! Data
+        let data = serviceDataDict[serviceUUID] as! Data
         // offset data
         let dataF = FlutterStandardTypedData(bytes: data.dropFirst(offset.intValue))
         // All data must start with 0x0D
@@ -132,5 +140,20 @@ class BluetoothScanner: NSObject, CBCentralManagerDelegate, DTGPayloadApi {
             return nil
         }
         return dataF
+    }
+
+    // Restarts scanning if it was running, depending on current priority
+    private func restartScan() {
+        // if scan is running when settting high prio, call scan to restart and set timer
+        // if scan is running when setting low prio, just cancel restart timer
+        if centralManager.isScanning {
+            if scanPriority == .low {
+                restartTimer?.invalidate()
+            }
+            else {
+                centralManager.stopScan()
+                scan()
+            }
+        }
     }
 }

--- a/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
@@ -70,10 +70,12 @@ public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
         return ((false) as NSNumber?, nil)
     }
 
-    public func startScanBluetooth(completion: @escaping (FlutterError?) -> Void) {
+    public func startScanBluetoothServiceUuid(_ serviceUuid: String?, completion: @escaping (FlutterError?) -> Void) {
         guard let scanner = bluetoothScanner else {
             return completion(PluginNotInitializedException.init())
         }
+
+        scanner.setServiceUuid(value: serviceUuid)
         scanner.scan()
         completion(nil)
     }

--- a/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
+++ b/ios/Classes/SwiftFlutterOpendroneidPlugin.swift
@@ -102,6 +102,14 @@ public class SwiftFlutterOpendroneidPlugin: NSObject, FlutterPlugin, DTGApi{
         scanner.setScanPriority(priority: priority)
         return nil
     }
+
+    public func setBtServiceUuidServiceUuid(_ serviceUuid: String?) async -> FlutterError? {
+        guard let scanner = bluetoothScanner else {
+            return PluginNotInitializedException.init()
+        }
+        scanner.setServiceUuid(value: serviceUuid)
+        return nil
+    }
     
     public func isScanningBluetooth() async -> (NSNumber?, FlutterError?) {
         guard let scanner = bluetoothScanner else {

--- a/ios/Classes/pigeon.h
+++ b/ios/Classes/pigeon.h
@@ -70,7 +70,7 @@ NSObject<FlutterMessageCodec> *DTGApiGetCodec(void);
 @protocol DTGApi
 - (void)initializeWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)isInitializedWithCompletion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
-- (void)startScanBluetoothWithCompletion:(void (^)(FlutterError *_Nullable))completion;
+- (void)startScanBluetoothServiceUuid:(nullable NSString *)serviceUuid completion:(void (^)(FlutterError *_Nullable))completion;
 - (void)startScanWifiWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopScanBluetoothWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopScanWifiWithCompletion:(void (^)(FlutterError *_Nullable))completion;

--- a/ios/Classes/pigeon.h
+++ b/ios/Classes/pigeon.h
@@ -75,6 +75,7 @@ NSObject<FlutterMessageCodec> *DTGApiGetCodec(void);
 - (void)stopScanBluetoothWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)stopScanWifiWithCompletion:(void (^)(FlutterError *_Nullable))completion;
 - (void)setBtScanPriorityPriority:(DTGScanPriority)priority completion:(void (^)(FlutterError *_Nullable))completion;
+- (void)setBtServiceUuidServiceUuid:(nullable NSString *)serviceUuid completion:(void (^)(FlutterError *_Nullable))completion;
 - (void)isScanningBluetoothWithCompletion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)isScanningWifiWithCompletion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;
 - (void)bluetoothStateWithCompletion:(void (^)(NSNumber *_Nullable, FlutterError *_Nullable))completion;

--- a/ios/Classes/pigeon.m
+++ b/ios/Classes/pigeon.m
@@ -124,9 +124,11 @@ void DTGApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<DTGApi> *a
         binaryMessenger:binaryMessenger
         codec:DTGApiGetCodec()];
     if (api) {
-      NSCAssert([api respondsToSelector:@selector(startScanBluetoothWithCompletion:)], @"DTGApi api (%@) doesn't respond to @selector(startScanBluetoothWithCompletion:)", api);
+      NSCAssert([api respondsToSelector:@selector(startScanBluetoothServiceUuid:completion:)], @"DTGApi api (%@) doesn't respond to @selector(startScanBluetoothServiceUuid:completion:)", api);
       [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
-        [api startScanBluetoothWithCompletion:^(FlutterError *_Nullable error) {
+        NSArray *args = message;
+        NSString *arg_serviceUuid = GetNullableObjectAtIndex(args, 0);
+        [api startScanBluetoothServiceUuid:arg_serviceUuid completion:^(FlutterError *_Nullable error) {
           callback(wrapResult(nil, error));
         }];
       }];

--- a/ios/Classes/pigeon.m
+++ b/ios/Classes/pigeon.m
@@ -209,6 +209,25 @@ void DTGApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<DTGApi> *a
   {
     FlutterBasicMessageChannel *channel =
       [[FlutterBasicMessageChannel alloc]
+        initWithName:@"dev.flutter.pigeon.flutter_opendroneid.Api.setBtServiceUuid"
+        binaryMessenger:binaryMessenger
+        codec:DTGApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(setBtServiceUuidServiceUuid:completion:)], @"DTGApi api (%@) doesn't respond to @selector(setBtServiceUuidServiceUuid:completion:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        NSString *arg_serviceUuid = GetNullableObjectAtIndex(args, 0);
+        [api setBtServiceUuidServiceUuid:arg_serviceUuid completion:^(FlutterError *_Nullable error) {
+          callback(wrapResult(nil, error));
+        }];
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [[FlutterBasicMessageChannel alloc]
         initWithName:@"dev.flutter.pigeon.flutter_opendroneid.Api.isScanningBluetooth"
         binaryMessenger:binaryMessenger
         codec:DTGApiGetCodec()];

--- a/ios/Classes/utils/Utils.swift
+++ b/ios/Classes/utils/Utils.swift
@@ -23,3 +23,9 @@ extension Data {
         }
     }
 }
+
+extension String {
+    var isHexNumber: Bool {
+        filter(\.isHexDigit).count == count
+    }
+}

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -16,6 +16,7 @@ export 'package:dart_opendroneid/src/types.dart';
 
 class FlutterOpenDroneId {
   static late pigeon.Api _api = pigeon.Api();
+
   // event channels
   static const bluetoothOdidPayloadEventChannel =
       const EventChannel('flutter_odid_data_bt');
@@ -67,13 +68,18 @@ class FlutterOpenDroneId {
   ///
   /// For Wi-Fi scanning, location permission is required on Android.
   ///
+  /// By specifying [bluetoothServiceUuid] the service UUID of ODID BT
+  /// packets will be changed to the desired value. Standard 8-byte value in
+  /// hexadecimal format is expected, default is the standardized value - FFFA.
+  ///
   /// Throws [PermissionsMissingException] if permissions were not granted.
   ///
   /// To further receive data, listen to [receivedMessages]
   /// stream.
   ///
   /// Plugin must be initialized by calling [initialize] before using.
-  static Future<void> startScan(DriSourceType sourceType) async {
+  static Future<void> startScan(DriSourceType sourceType,
+      {String? bluetoothServiceUuid = "fffa"}) async {
     if (sourceType == DriSourceType.Bluetooth) {
       await _assertBluetoothPermissions();
       _receivedBluetoothMessagesSubscription?.cancel();
@@ -81,7 +87,7 @@ class FlutterOpenDroneId {
           .receiveBroadcastStream()
           .listen(
               (payload) => _handlePayload(pigeon.ODIDPayload.decode(payload)));
-      await _api.startScanBluetooth();
+      await _api.startScanBluetooth(bluetoothServiceUuid);
     } else if (sourceType == DriSourceType.Wifi) {
       await _assertWifiPermissions();
       _receivedWiFiMessagesSubscription?.cancel();

--- a/lib/flutter_opendroneid.dart
+++ b/lib/flutter_opendroneid.dart
@@ -116,6 +116,10 @@ class FlutterOpenDroneId {
     await _api.setBtScanPriority(priority);
   }
 
+  static Future<void> setBtServiceUuid(String? serviceUuid) async {
+    await _api.setBtServiceUuid(serviceUuid);
+  }
+
   static Future<bool> get isScanningBluetooth async {
     return _api.isScanningBluetooth();
   }

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -147,12 +147,12 @@ class Api {
     }
   }
 
-  Future<void> startScanBluetooth() async {
+  Future<void> startScanBluetooth(String? arg_serviceUuid) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.flutter_opendroneid.Api.startScanBluetooth', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
-        await channel.send(null) as List<Object?>?;
+        await channel.send(<Object?>[arg_serviceUuid]) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -257,6 +257,28 @@ class Api {
     }
   }
 
+  Future<void> setBtServiceUuid(String? arg_serviceUuid) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.flutter_opendroneid.Api.setBtServiceUuid', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(<Object?>[arg_serviceUuid]) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<bool> isScanningBluetooth() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.flutter_opendroneid.Api.isScanningBluetooth', codec,

--- a/pigeon/schema.dart
+++ b/pigeon/schema.dart
@@ -64,7 +64,7 @@ abstract class Api {
   @async
   bool isInitialized();
   @async
-  void startScanBluetooth();
+  void startScanBluetooth(String? serviceUuid);
   @async
   void startScanWifi();
   @async

--- a/pigeon/schema.dart
+++ b/pigeon/schema.dart
@@ -74,6 +74,8 @@ abstract class Api {
   @async
   void setBtScanPriority(ScanPriority priority);
   @async
+  void setBtServiceUuid(String? serviceUuid);
+  @async
   bool isScanningBluetooth();
   @async
   bool isScanningWifi();


### PR DESCRIPTION
Based on `beta` branch.

The `startScan` function now optionally allows specifying different BT service UUID from which ODID packets are expected. Default value is `FFFA` which is standardized as "ASTM RID".

Internally, service UUID is no longer a constant, but a value computed from currently set "short service UUID" (e.g. `FFFA`) value. Bluetooth scanner now implements `setServiceUuid` which configures this short service UUID and restarts scanning if necessary.

Tested in Dronetag App (further changes necessary, see Jira issue for more details).