### PR TITLE
fix(android): cancel scan when bluetooth is system disabled

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -102,9 +102,9 @@ class BluetoothScanner(
     }
 
     override fun cancel() {
+        if (!isScanning) return
         isScanning = false
         bluetoothStateHandler.send(false)
-        if (!bluetoothAdapter.isEnabled) return
         bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
     }
 


### PR DESCRIPTION
**Context:**
On Android, app can scan using BT even when BT is disabled in system settings. To keep the behaviour consistent we cancel scan when BT is system disabled, DS2 shows that BT is unavailable.

But there was an error that caused scan to not cancel, app continued to receive data even when BT is disabled on system.

**Fix:**
I fixed the `cancel` method in `BluetoothScanner.kt`.
There was check ` if (!bluetoothAdapter.isEnabled) return` that was supposed to prevent canceling when scanning is not active, but it was wrong. `bluetoothAdapter.isEnabled `is just other way of writing `adapterState == .stateOn`, so cancel returned early and did not actually cancel the scan when BT was disabled (`adapterState == .stateOff`).  
I replaced it with `if (!isScanning) return`.

**Testing:**
Build DS2 with this version of flutter-opendroneid, start scanning and turn of BT in system settings. You should see that app stopped receiving new data and BT is in _'unavailable'_ state.
