### PR TITLE
fix: Add null check in BluetoothLeScanner while stopping the scan

### DIFF
--- a/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
+++ b/android/src/main/kotlin/cz/dronetag/flutter_opendroneid/scanner/BluetoothScanner.kt
@@ -113,7 +113,7 @@ class BluetoothScanner(
         if (!isScanning) return
         isScanning = false
         bluetoothStateHandler.send(false)
-        bluetoothAdapter.bluetoothLeScanner.stopScan(scanCallback)
+        bluetoothAdapter.bluetoothLeScanner?.stopScan(scanCallback)
     }
 
     @RequiresApi(Build.VERSION_CODES.O)


### PR DESCRIPTION
This PR fixes a `NullPointerException` crash that occurs when Bluetooth is turned off after detecting a drone. The crash was caused by the plugin attempting to call `stopScan()` on a null `BluetoothLeScanner` in `BluetoothScanner.cancel()`.

## Problem Addressed
The app was crashing when Bluetooth was disabled on an Android device after detecting a drone, with the following stack trace:
```

E/AndroidRuntime: FATAL EXCEPTION: main
E/AndroidRuntime: java.lang.RuntimeException: Error receiving broadcast Intent { act=android.bluetooth.adapter.action.STATE_CHANGED flg=0x1000010 (has extras) } in cz.dronetag.flutter_opendroneid.ODIDScanner$adapterStateReceiver$1@580ed7b
E/AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.bluetooth.le.BluetoothLeScanner.stopScan(android.bluetooth.le.ScanCallback)' on a null object reference
E/AndroidRuntime:  at cz.dronetag.flutter_opendroneid.BluetoothScanner.cancel(BluetoothScanner.kt:116)
```

I added the null check in android/src/main/kotlin/cz/dronetag/flutter_opendroneid/BluetoothScanner.kt to fix the crash.
Thus, this PR resolves this crash issue