### PR TITLE
Bumped `dart_opendroneid` to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ end
 
 ---
 
-&copy; [Dronetag 2025](https://www.dronetag.cz)  
-<a href="https://www.dronetag.cz"><img src="http://dronetag-media.s3.eu-north-1.amazonaws.com/d69bc916-7137-469c-88c4-22b7ad0cdf33.png" width="100" /></a>
+&copy; [Dronetag 2026](https://www.dronetag.com)
+<a href="https://www.dronetag.com"><img src="http://dronetag-media.s3.eu-north-1.amazonaws.com/d69bc916-7137-469c-88c4-22b7ad0cdf33.png" width="100" /></a>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   permission_handler: ^12.0.0
   device_info_plus: ^9.1.2
-  dart_opendroneid: ^0.7.3
+  dart_opendroneid: ^1.0.0
 dev_dependencies:
   pigeon: ^10.1.6
 flutter:


### PR DESCRIPTION
As the `dart_opendroneid` package was recently promoted to v1.0.0, this PR bumps this dependency.

README footer was also updated with new Dronetag website URL and 2026 copyright notice.